### PR TITLE
Add in `urlConnect` function to unify dispatch and url updating

### DIFF
--- a/src/containers/LocationPage/LocationPage.jsx
+++ b/src/containers/LocationPage/LocationPage.jsx
@@ -29,13 +29,13 @@ const urlQueryConfig = {
 const urlHandler = new UrlHandler(urlQueryConfig, browserHistory);
 
 
-function mapStateToProps(state, props) {
+function mapStateToProps(state, propsWithUrl) {
   return {
-    ...props,
-    viewMetric: LocationPageSelectors.getViewMetric(state, props),
-    hourly: LocationPageSelectors.getActiveLocationHourly(state, props),
-    timeSeries: LocationPageSelectors.getActiveLocationTimeSeries(state, props),
-    highlightHourly: LocationPageSelectors.getHighlightHourly(state, props),
+    ...propsWithUrl,
+    viewMetric: LocationPageSelectors.getViewMetric(state, propsWithUrl),
+    hourly: LocationPageSelectors.getActiveLocationHourly(state, propsWithUrl),
+    timeSeries: LocationPageSelectors.getActiveLocationTimeSeries(state, propsWithUrl),
+    highlightHourly: LocationPageSelectors.getHighlightHourly(state, propsWithUrl),
   };
 }
 

--- a/src/containers/LocationPage/LocationPage.jsx
+++ b/src/containers/LocationPage/LocationPage.jsx
@@ -1,5 +1,4 @@
 import React, { PureComponent, PropTypes } from 'react';
-import { connect } from 'react-redux';
 import Helmet from 'react-helmet';
 import classNames from 'classnames';
 import { browserHistory } from 'react-router';
@@ -10,8 +9,11 @@ import * as LocationPageActions from '../../redux/locationPage/actions';
 import * as LocationsActions from '../../redux/locations/actions';
 
 import { ChartExportControls, LineChart, HourChart } from '../../components';
-import UrlHandler from '../../utils/UrlHandler';
+import UrlHandler from '../../url/UrlHandler';
+import urlConnect from '../../url/urlConnect';
 
+
+// Define how to read/write state to URL query parameters
 const urlQueryConfig = {
   viewMetric: { type: 'string', defaultValue: 'download', urlKey: 'metric' },
 
@@ -26,22 +28,14 @@ const urlQueryConfig = {
 };
 const urlHandler = new UrlHandler(urlQueryConfig, browserHistory);
 
+
 function mapStateToProps(state, props) {
-  // combine props with those read from URL to provide to Redux selectors
-  const propsWithUrl = {
-    ...props,
-    locationId: props.params.locationId,
-
-    // adds in: showBaselines, showRegionalValues, ... etc
-    ...urlHandler.decodeQuery(props.location.query),
-  };
-
   return {
-    ...propsWithUrl,
-    viewMetric: LocationPageSelectors.getViewMetric(state, propsWithUrl),
-    hourly: LocationPageSelectors.getActiveLocationHourly(state, propsWithUrl),
-    timeSeries: LocationPageSelectors.getActiveLocationTimeSeries(state, propsWithUrl),
-    highlightHourly: LocationPageSelectors.getHighlightHourly(state, propsWithUrl),
+    ...props,
+    viewMetric: LocationPageSelectors.getViewMetric(state, props),
+    hourly: LocationPageSelectors.getActiveLocationHourly(state, props),
+    timeSeries: LocationPageSelectors.getActiveLocationTimeSeries(state, props),
+    highlightHourly: LocationPageSelectors.getHighlightHourly(state, props),
   };
 }
 
@@ -66,9 +60,8 @@ class LocationPage extends PureComponent {
 
     // bind handlers
     this.handleHighlightHourly = this.handleHighlightHourly.bind(this);
-    this.handleShowBaselinesChange = this.handleCheckboxChange.bind(this, 'showBaselines');
-    this.handleShowRegionalValuesChange = this.handleCheckboxChange.bind(this,
-      'showRegionalValues');
+    this.handleShowBaselinesChange = this.handleShowBaselinesChange.bind(this);
+    this.handleShowRegionalValuesChange = this.handleShowRegionalValuesChange.bind(this);
   }
 
   componentDidMount() {
@@ -100,25 +93,38 @@ class LocationPage extends PureComponent {
     return extentKey;
   }
 
-  // update the URL on checkbox change
-  handleCheckboxChange(key, evt) {
-    const { location } = this.props;
+  /**
+   * Callback for show baselines checkbox
+   */
+  handleShowBaselinesChange(evt) {
+    const { dispatch } = this.props;
     const { checked } = evt.target;
-    urlHandler.replaceInQuery(location, key, checked);
+    dispatch(LocationPageActions.changeShowBaselines(checked));
   }
 
-  // update the URL on time aggregation change
+  /**
+   * Callback for show regional values checkbox
+   */
+  handleShowRegionalValuesChange(evt) {
+    const { dispatch } = this.props;
+    const { checked } = evt.target;
+    dispatch(LocationPageActions.changeShowRegionalValues(checked));
+  }
+
+  /**
+   * Callback for time aggregation checkbox
+   */
   handleTimeAggregationChange(value) {
-    const { location } = this.props;
-    urlHandler.replaceInQuery(location, 'timeAggregation', value);
+    const { dispatch } = this.props;
+    dispatch(LocationPageActions.changeTimeAggregation(value));
   }
 
   /**
    * Callback for when viewMetric changes - updates URL
    */
   handleViewMetricChange(value) {
-    const { location } = this.props;
-    urlHandler.replaceInQuery(location, 'viewMetric', value);
+    const { dispatch } = this.props;
+    dispatch(LocationPageActions.changeViewMetric(value));
   }
 
   /**
@@ -337,4 +343,4 @@ class LocationPage extends PureComponent {
   }
 }
 
-export default connect(mapStateToProps)(LocationPage);
+export default urlConnect(urlHandler, mapStateToProps)(LocationPage);

--- a/src/redux/locationPage/actions.js
+++ b/src/redux/locationPage/actions.js
@@ -1,6 +1,8 @@
 /**
  * Actions for locationPage
  */
+import { urlReplaceAction } from '../../url/actions';
+
 export const HIGHLIGHT_HOURLY = 'locationPage/HIGHLIGHT_HOURLY';
 
 /**
@@ -12,3 +14,9 @@ export function highlightHourly(highlightPoint) {
     highlightPoint,
   };
 }
+
+/** Actions that replace values in the URL */
+export const changeTimeAggregation = urlReplaceAction('timeAggregation');
+export const changeViewMetric = urlReplaceAction('viewMetric');
+export const changeShowBaselines = urlReplaceAction('showBaselines');
+export const changeShowRegionalValues = urlReplaceAction('showRegionalValues');

--- a/src/url/UrlHandler.js
+++ b/src/url/UrlHandler.js
@@ -2,7 +2,7 @@
  * Functions for working with URL parameters via react-router
  */
 
-import { decode, encode } from './serialization';
+import { decode, encode } from '../utils/serialization';
 
 export default class UrlHandler {
   /**

--- a/src/url/actions.js
+++ b/src/url/actions.js
@@ -1,0 +1,14 @@
+export const URL_REPLACE = 'URL_REPLACE';
+
+/**
+ * Helper function for creating URL_REPLACE actions
+ */
+export function urlReplaceAction(key) {
+  return function urlReplaceActionCreator(value) {
+    return {
+      type: URL_REPLACE,
+      key,
+      value,
+    };
+  };
+}

--- a/src/url/actions.js
+++ b/src/url/actions.js
@@ -2,6 +2,10 @@ export const URL_REPLACE = 'URL_REPLACE';
 
 /**
  * Helper function for creating URL_REPLACE actions
+ *
+ * For example in your actions.js file:
+ * export const changeTimeAggregation = urlReplaceAction('timeAggregation');
+ *
  */
 export function urlReplaceAction(key) {
   return function urlReplaceActionCreator(value) {

--- a/src/url/urlConnect.jsx
+++ b/src/url/urlConnect.jsx
@@ -38,6 +38,10 @@ export default function urlConnect(urlHandler, mapStateToProps, mapDispatchToPro
     return mapStateToProps ? mapStateToProps(state, propsWithUrl) : propsWithUrl;
   }
 
+  /**
+   * Function to actually do the wrapping. do it this way instead of making WrappedComponent
+   * an argument of urlConnect so you don't need to supply all of `connect`'s  arguments.
+   */
   function wrapComponentWithUrlConnect(WrappedComponent) {
     const componentDisplayName = WrappedComponent.displayName ||
       WrappedComponent.name || 'Component';
@@ -74,6 +78,10 @@ export default function urlConnect(urlHandler, mapStateToProps, mapDispatchToPro
         }
       }
 
+      /**
+       * Overwrites the `dispatch` prop with `this.urlConnectDispatch` and retains
+       * the original value as `reduxDispatch` in props.
+       */
       render() {
         return (
           <WrappedComponent

--- a/src/url/urlConnect.jsx
+++ b/src/url/urlConnect.jsx
@@ -1,0 +1,96 @@
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { URL_REPLACE } from './actions';
+
+/**
+ * Decorator for a react component class that adds in dispatching for URL actions
+ * and Redux actions via the standard redux `dispatch` prop. Also integrates
+ * props from the URL into the props received by mapStateToProps based on the
+ * urlHandler passed in (which gets it from a urlConfig).
+ *
+ * Should be used in place of react-redux's `connect`. For example:
+ *
+ * export default urlConnect(urlHandler, mapStateToProps)(LocationPage);
+ *
+ * @param {Object} urlHandler A UrlHandler instance
+ * @param {Function} mapStateToProps as for `connect`
+ * @param {Function} mapDispatchToProps as for `connect`
+ * @param {Function} mergeProps as for `connect`
+ * @param {Object} options as for `connect`
+ * @return {React.Component} A react component, enhanced with redux, react-router
+ *   and UrlHandler integration
+ */
+export default function urlConnect(urlHandler, mapStateToProps, mapDispatchToProps,
+  mergeProps, options = {}) {
+  // if no URL handler, just use react-redux connect
+  if (!urlHandler) {
+    return connect(mapStateToProps, mapDispatchToProps, mergeProps, options);
+  }
+
+  // otherwise, add in query params to mapStateToProps
+  function mapStateToPropsWithUrl(state, props) {
+    const propsWithUrl = {
+      ...urlHandler.decodeQuery(props.location.query),
+      ...props.params,
+      ...props,
+    };
+
+    return mapStateToProps ? mapStateToProps(state, propsWithUrl) : propsWithUrl;
+  }
+
+  function wrapComponentWithUrlConnect(WrappedComponent) {
+    const componentDisplayName = WrappedComponent.displayName ||
+      WrappedComponent.name || 'Component';
+    const urlConnectDisplayName = `UrlConnect(${componentDisplayName})`;
+
+    class UrlConnect extends Component {
+      static propTypes = {
+        dispatch: PropTypes.func,
+        location: PropTypes.object,
+      }
+
+      // bind urlConnectDispatch so we don't create a new function each time render is called
+      constructor(...args) {
+        super(...args);
+        this.urlConnectDispatch = this.urlConnectDispatch.bind(this);
+      }
+
+      /**
+       * The new dispatch function that chooses between redux's dispatch
+       * and updating the URL based on the type of the action.
+       */
+      urlConnectDispatch(action, ...other) {
+        const { location, dispatch } = this.props;
+        const { type } = action;
+
+        // handle with URL handler -- doesn't go to Redux dispatcher
+        if (type === URL_REPLACE) {
+          const { key, value } = action;
+          urlHandler.replaceInQuery(location, key, value);
+
+        // otherwise handle in Redux
+        } else {
+          dispatch(action, ...other);
+        }
+      }
+
+      render() {
+        return (
+          <WrappedComponent
+            {...this.props}
+            reduxDispatch={this.props.dispatch}
+            dispatch={this.urlConnectDispatch}
+          />
+        );
+      }
+    }
+
+    UrlConnect.displayName = urlConnectDisplayName;
+    UrlConnect.WrappedComponent = WrappedComponent;
+    UrlConnect.urlHandler = urlHandler;
+
+    return connect(mapStateToPropsWithUrl, mapDispatchToProps, mergeProps, options)(UrlConnect);
+  }
+
+  return wrapComponentWithUrlConnect;
+}


### PR DESCRIPTION
Adds in a decorator for components to wrap URL updating functionality so the components themselves do not need to know about it. It is currently encoded directly in the action type, although that could change.