### PR TITLE
Add counts to line chart

### DIFF
--- a/src/components/CountChart/CountChart.jsx
+++ b/src/components/CountChart/CountChart.jsx
@@ -83,7 +83,7 @@ export default class CountChart extends PureComponent {
 
     // render a line for the x-axis (no ticks)
     this.xAxis = this.g.append('g').classed('x-axis', true)
-      .attr('transform', `translate(${binWidth / 2} ${innerHeight})`);
+      .attr('transform', `translate(0 ${innerHeight})`);
 
     this.xAxis.append('line')
       .attr('x1', 0)

--- a/src/components/HourChart/HourChart.jsx
+++ b/src/components/HourChart/HourChart.jsx
@@ -357,7 +357,7 @@ export default class HourChart extends PureComponent {
    * @return {React.Component} The rendered container
    */
   render() {
-    const { inSvg, width, id, height } = this.props;
+    const { height, inSvg, id, width } = this.props;
 
     if (inSvg) {
       return (

--- a/src/components/HourChart/HourChartWithCounts.jsx
+++ b/src/components/HourChart/HourChartWithCounts.jsx
@@ -128,10 +128,12 @@ export default class HourChartWithCounts extends PureComponent {
 
     const xDomain = [0, 23];
     const xScale = d3.scaleLinear().domain(xDomain).range([xMin, xMax]);
+    const numBins = 24; // one for each hour
 
     return {
       ...preparedData,
       innerMargin,
+      numBins,
       xScale,
     };
   }
@@ -143,7 +145,7 @@ export default class HourChartWithCounts extends PureComponent {
   render() {
     const { height, id, width } = this.props;
     const { dataByHour, dataByDate, filteredData, innerMargin, overallData,
-      xScale } = this.visComponents;
+      xScale, numBins } = this.visComponents;
 
     const hourHeight = height * 0.75;
     const countHeight = height - hourHeight;
@@ -153,7 +155,6 @@ export default class HourChartWithCounts extends PureComponent {
         <svg
           id={id}
           className="hour-chart-with-counts chart"
-          ref={node => { this.root = node; }}
           width={width}
           height={height}
         >
@@ -179,7 +180,7 @@ export default class HourChartWithCounts extends PureComponent {
               height={countHeight}
               innerMarginLeft={innerMargin.left}
               innerMarginRight={innerMargin.right}
-              numBins={24}
+              numBins={numBins}
               width={width}
               xKey="hour"
               xScale={xScale}

--- a/src/components/LineChart/LineChartWithCounts.jsx
+++ b/src/components/LineChart/LineChartWithCounts.jsx
@@ -1,0 +1,146 @@
+import React, { PureComponent, PropTypes } from 'react';
+import { groupBy } from 'lodash';
+import d3 from 'd3';
+
+import { LineChart, CountChart } from '../../components';
+import { sum, weightedAverage } from '../../utils/math';
+
+/**
+ * Chart for showing line and count together.
+ *
+ * @prop {Array} data The array of data points to render (e.g., [{x: Date, y: Number}, ...])
+ * @prop {Boolean} forceZeroMin=true Whether the min y value should always be 0.
+ * @prop {Number} height The height in pixels of the SVG chart
+ * @prop {String} id The ID of the SVG chart (needed for PNG export)
+ * @prop {Number} width The width in pixels of the SVG chart
+ * @prop {Array} xExtent The min and max value of the xKey in the chart
+ * @prop {String} xKey="x" The key to read the x value from in the data
+ * @prop {Array} yExtent The min and max value of the yKey in the chart
+ * @prop {String} yKey="y" The key to read the y value from in the data
+ */
+export default class LineChartWithCounts extends PureComponent {
+  static propTypes = {
+    data: PropTypes.array,
+    forceZeroMin: PropTypes.bool,
+    height: React.PropTypes.number,
+    id: React.PropTypes.string,
+    width: React.PropTypes.number,
+    xExtent: PropTypes.array,
+    xKey: React.PropTypes.string,
+    yExtent: PropTypes.array,
+    yKey: React.PropTypes.string,
+  }
+
+  static defaultProps = {
+    threshold: 30,
+  }
+
+  /**
+   * Initiailize the vis components when the component is about to mount
+   */
+  componentWillMount() {
+    this.visComponents = this.makeSharedVisComponents(this.props);
+  }
+
+  /**
+   * When new props are received, regenerate vis components if necessary
+   */
+  componentWillReceiveProps(nextProps) {
+    // regenerate the vis components if the relevant props change
+    this.visComponents = this.makeSharedVisComponents(nextProps);
+  }
+
+  /**
+   * Filter the data
+   * @param {Object} props the component props
+   * @return {Array} the prepared data
+   */
+  prepareData(props) {
+    const { data, xKey, yKey } = props;
+    // filter out points with missing values
+    const filteredData = (data || []).filter(d => d[xKey] != null && d[yKey] != null);
+
+    return filteredData;
+  }
+
+
+  /**
+   * Figure out what is needed for both charts
+   */
+  makeSharedVisComponents(props) {
+    const { width, xExtent, xKey } = props;
+
+    const filteredData = this.prepareData(props);
+    const innerMargin = {
+      right: 50,
+      left: 50,
+    };
+    const innerWidth = width - innerMargin.left - innerMargin.right;
+
+    const xMin = 0;
+    const xMax = innerWidth;
+
+    const xDomain = xExtent || d3.extent(filteredData, d => d[xKey]);
+    const xScale = d3.scaleTime().domain(xDomain).range([xMin, xMax]);
+    // TODO - this is incorrect in the event that there is missing data.
+    // e.g. Jan 1, Jan 2, Jan 4, Jan 5, Jan 6. = 5 bins, but should be 6.
+    const numBins = filteredData.length || 1;
+
+    return {
+      filteredData,
+      innerMargin,
+      numBins,
+      xScale,
+    };
+  }
+
+  /**
+   * The main render method. Defers chart rendering to d3 in `update` and `setup`
+   * @return {React.Component} The rendered container
+   */
+  render() {
+    const { height, id, width, xKey } = this.props;
+    const { filteredData, innerMargin, xScale, numBins } = this.visComponents;
+
+    const lineChartHeight = height * 0.75;
+    const countHeight = height - lineChartHeight;
+
+    return (
+      <div className="line-chart-with-counts-container">
+        <svg
+          id={id}
+          className="line-chart-with-counts chart"
+          width={width}
+          height={height}
+        >
+          <rect x={0} y={0} width={width} height={height} fill={'#fff'} />
+          <g>
+            <LineChart
+              {...this.props}
+              data={filteredData}
+              id={undefined}
+              inSvg
+              height={lineChartHeight}
+              innerMarginLeft={innerMargin.left}
+              innerMarginRight={innerMargin.right}
+              xScale={xScale}
+            />
+          </g>
+          <g transform={`translate(0 ${lineChartHeight})`}>
+            <CountChart
+              data={filteredData}
+              height={countHeight}
+              innerMarginLeft={innerMargin.left}
+              innerMarginRight={innerMargin.right}
+              numBins={numBins}
+              width={width}
+              xKey={xKey}
+              xScale={xScale}
+            />
+          </g>
+        </svg>
+      </div>
+    );
+  }
+
+}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -9,6 +9,7 @@ export ChartExportControls from './ChartExportControls/ChartExportControls';
 export Icon from './Icon/Icon';
 export JsonDump from './JsonDump/JsonDump';
 export LineChart from './LineChart/LineChart';
+export LineChartWithCounts from './LineChart/LineChartWithCounts';
 export HourChart from './HourChart/HourChart';
 export HourChartWithCounts from './HourChart/HourChartWithCounts';
 export CountChart from './CountChart/CountChart';

--- a/src/containers/LocationPage/LocationPage.jsx
+++ b/src/containers/LocationPage/LocationPage.jsx
@@ -8,7 +8,7 @@ import * as LocationPageSelectors from '../../redux/locationPage/selectors';
 import * as LocationPageActions from '../../redux/locationPage/actions';
 import * as LocationsActions from '../../redux/locations/actions';
 
-import { ChartExportControls, LineChart, HourChartWithCounts } from '../../components';
+import { ChartExportControls, LineChartWithCounts, HourChartWithCounts } from '../../components';
 import UrlHandler from '../../url/UrlHandler';
 import urlConnect from '../../url/urlConnect';
 
@@ -239,10 +239,10 @@ class LocationPage extends PureComponent {
     return (
       <div>
         <h3>Compare Providers</h3>
-        <LineChart
+        <LineChartWithCounts
           id={chartId}
           data={chartData}
-          height={300}
+          height={400}
           width={800}
           yExtent={timeSeries && timeSeries.results.extents.date}
           xKey="date"


### PR DESCRIPTION
First pass at adding counts to line chart. Adds **LineChartWithCounts**.

Some work needs to be done about binning in general due to this issue:

Jan 1, Jan 2, Jan 4, Jan 5, Jan 6. = 5 bins by data.length, but should be 6.

![image](https://cloud.githubusercontent.com/assets/793847/17866639/48540778-6875-11e6-9b41-843341aff9b1.png)
