### PR TITLE
Get fixed data for selected client ISPs and add to summary

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -117,3 +117,15 @@ export function getLocationSearch(searchQuery) {
   return get(`/locations/search/${searchQuery}`)
     .then(transform(transformSearchResults));
 }
+
+/**
+ * Get information for a client ISP in a location
+ *
+ * @param {String} locationId The location to query (e.g., nauswaseattle)
+ * @param {String} clientIspId The AS number of the ISP (e.g., AS7922)
+ * @return {Promise} A promise after the get request was made
+ */
+export function getLocationClientIspInfo(locationId, clientIspId) {
+  return get(`/locations/${locationId}/clientisps/${clientIspId}/info`)
+    .then(transform(transformFixedData));
+}

--- a/src/api/transforms.js
+++ b/src/api/transforms.js
@@ -217,6 +217,7 @@ export function transformFixedData(body) {
   if (body.data) {
     const keyMapping = {
       last_year_: 'lastYear',
+      other: 'other',
     };
 
     const mappedKeys = Object.keys(keyMapping);
@@ -230,14 +231,14 @@ export function transformFixedData(body) {
         }
       }
 
-      return 'general';
+      return 'other';
     }).object(Object.keys(body.data));
 
     // convert to an object
     // e.g. { lastYear: { download_avg: ... }, ... }
     body.data = Object.keys(keyGroups).reduce((groupedData, key) => {
       groupedData[keyMapping[key]] = keyGroups[key].reduce((keyData, dataKey) => {
-        const newDataKey = dataKey.substring(key.length);
+        const newDataKey = key === 'other' ? dataKey : dataKey.substring(key.length);
         keyData[newDataKey] = body.data[dataKey];
 
         return keyData;

--- a/src/containers/LocationPage/LocationPage.jsx
+++ b/src/containers/LocationPage/LocationPage.jsx
@@ -149,6 +149,7 @@ class LocationPage extends PureComponent {
         dispatch(
           LocationsActions.fetchClientIspLocationTimeSeriesIfNeeded(timeAggregation, locationId, clientIspId, options)
         );
+        dispatch(LocationsActions.fetchClientIspInfoIfNeeded(locationId, clientIspId));
       });
     }
   }

--- a/src/redux/locationPage/selectors.js
+++ b/src/redux/locationPage/selectors.js
@@ -176,14 +176,14 @@ export const getTimeSeriesStatus = createSelector(
  * Selector to get the summary data for the location and related ISPs
  */
 export const getSummaryData = createSelector(
-  getLocationInfo, getLocationFixed, // getLocationClientIspFixed, (TODO add client ISP fixed data)
-  (locationInfo, locationFixed, locationClientIspFixed) => {
+  getLocationInfo, getLocationFixed, getLocationSelectedClientIsps,
+  (locationInfo, locationFixed, selectedClientIsps) => {
     if (!locationFixed) {
       return undefined;
     }
 
-    if (!locationClientIspFixed) {
-      locationClientIspFixed = [];
+    if (!selectedClientIsps) {
+      selectedClientIsps = [];
     }
 
     // gropu all the `lastYear`, `lastweek`, etc together
@@ -193,11 +193,16 @@ export const getSummaryData = createSelector(
         label: locationInfo.name,
       };
 
-      // add in the results for client ISPs here (TODO - add in proper names)
-      const clientIspsData = locationClientIspFixed.map((ispFixed, i) => ({
-        ...ispFixed[key],
-        label: `clientIsp${i}`,
-      }));
+      // add in the results for client ISPs here
+      const clientIspsData = selectedClientIsps.map(clientIsp => {
+        const ispFixed = clientIsp.fixed.data || {};
+        const ispInfo = clientIsp.info.data || {};
+
+        return {
+          ...ispFixed[key],
+          label: ispInfo.client_asn_name,
+        };
+      });
 
       grouped[key] = [locationData, ...clientIspsData];
 

--- a/src/redux/locations/reducer.js
+++ b/src/redux/locations/reducer.js
@@ -22,7 +22,10 @@ function locations(state = initialState, action = {}) {
     case Actions.FETCH_TOP_CLIENT_ISPS_FAIL:
     case Actions.FETCH_INFO:
     case Actions.FETCH_INFO_SUCCESS:
-    case Actions.FETCH_INFO_FAIL: {
+    case Actions.FETCH_INFO_FAIL:
+    case Actions.FETCH_CLIENT_ISP_INFO:
+    case Actions.FETCH_CLIENT_ISP_INFO_SUCCESS:
+    case Actions.FETCH_CLIENT_ISP_INFO_FAIL: {
       const { locationId } = action;
 
       return {

--- a/src/redux/locations/reducers/clientIsp.js
+++ b/src/redux/locations/reducers/clientIsp.js
@@ -50,11 +50,9 @@ function info(state = initialClientIspState.info, action = {}) {
         isFetched: false,
       };
     case Actions.FETCH_CLIENT_ISP_INFO_SUCCESS:
-      console.warn('TODO merging ISP Info due to API bug');
       return {
         // store the meta info directly
-        data: Object.assign({}, state.data, action.result.meta), // TODO temporarily copy from state.data to handle API bug of not having asn number or name
-        // data: action.result.meta,
+        data: action.result.meta,
         isFetching: false,
         isFetched: true,
       };

--- a/src/redux/locations/reducers/clientIsp.js
+++ b/src/redux/locations/reducers/clientIsp.js
@@ -50,9 +50,11 @@ function info(state = initialClientIspState.info, action = {}) {
         isFetched: false,
       };
     case Actions.FETCH_CLIENT_ISP_INFO_SUCCESS:
+      console.warn('TODO merging ISP Info due to API bug');
       return {
         // store the meta info directly
-        data: action.result.meta,
+        data: Object.assign({}, state.data, action.result.meta), // TODO temporarily copy from state.data to handle API bug of not having asn number or name
+        // data: action.result.meta,
         isFetching: false,
         isFetched: true,
       };

--- a/src/redux/locations/reducers/location.js
+++ b/src/redux/locations/reducers/location.js
@@ -158,6 +158,9 @@ function clientIsps(state = initialLocationState.clientIsps, action = {}) {
     case Actions.FETCH_CLIENT_ISP_TIME_SERIES:
     case Actions.FETCH_CLIENT_ISP_TIME_SERIES_SUCCESS:
     case Actions.FETCH_CLIENT_ISP_TIME_SERIES_FAIL:
+    case Actions.FETCH_CLIENT_ISP_INFO:
+    case Actions.FETCH_CLIENT_ISP_INFO_SUCCESS:
+    case Actions.FETCH_CLIENT_ISP_INFO_FAIL:
       return {
         ...state,
         [action.clientIspId]: clientIsp(state[action.clientIspId], action),
@@ -166,9 +169,11 @@ function clientIsps(state = initialLocationState.clientIsps, action = {}) {
     case Actions.FETCH_TOP_CLIENT_ISPS_SUCCESS: {
       const topIsps = action.result.results;
       let result = state;
+      // for each top ISP, see if we need to merge in info
       topIsps.forEach(topIsp => {
         const id = topIsp.client_asn_number;
         let clientIspState = state[id];
+        // if we don't have state for this client ISP yet, initialize to the default + id
         if (!clientIspState) {
           clientIspState = {
             ...initialClientIspState,
@@ -176,6 +181,7 @@ function clientIsps(state = initialLocationState.clientIsps, action = {}) {
           };
         }
 
+        // if we don't have info for this client ISP, use the top client ISP data
         if (!clientIspState.info.isFetched) {
           clientIspState = {
             ...clientIspState,
@@ -185,6 +191,8 @@ function clientIsps(state = initialLocationState.clientIsps, action = {}) {
               isFetched: true,
             },
           };
+
+          // update the result to have the new info data
           result = {
             ...result,
             [id]: clientIspState,


### PR DESCRIPTION
Gets the fixed data for selected ISPs and shows it in the summary table.

<del>Currently includes a fix for an API bug that should eventually be removed.</del>

![image](https://cloud.githubusercontent.com/assets/793847/18214540/79ceeecc-711b-11e6-8663-7a77466e75e0.png)
