### PR TITLE
Stop over-rerendering from happening with charts

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "express-session": "^1.12.1",
     "extract-text-webpack-plugin": "^0.9.1",
     "file-loader": "^0.9.0",
-    "hard-source-webpack-plugin": "0.0.25",
+    "hard-source-webpack-plugin": "0.0.32",
     "http-proxy": "^1.12.0",
     "jquery": "^3.1.0",
     "json-loader": "^0.5.4",

--- a/src/components/CountChart/CountChart.jsx
+++ b/src/components/CountChart/CountChart.jsx
@@ -45,9 +45,9 @@ export default class CountChart extends PureComponent {
   }
 
   /**
-   * When new props are received, regenerate vis components if necessary
+   * When new component is updating, regenerate vis components if necessary
    */
-  componentWillReceiveProps(nextProps) {
+  componentWillUpdate(nextProps) {
     // regenerate the vis components if the relevant props change
     this.visComponents = this.makeVisComponents(nextProps);
   }

--- a/src/components/HourChart/HourChart.jsx
+++ b/src/components/HourChart/HourChart.jsx
@@ -67,9 +67,9 @@ export default class HourChart extends PureComponent {
   }
 
   /**
-   * When new props are received, regenerate vis components if necessary
+   * When new component is updating, regenerate vis components if necessary
    */
-  componentWillReceiveProps(nextProps) {
+  componentWillUpdate(nextProps) {
     // regenerate the vis components if the relevant props change
     this.visComponents = this.makeVisComponents(nextProps);
   }

--- a/src/components/LineChart/LineChart.jsx
+++ b/src/components/LineChart/LineChart.jsx
@@ -53,9 +53,9 @@ export default class LineChart extends PureComponent {
   }
 
   /**
-   * When new props are received, regenerate vis components if necessary
+   * When new component is updating, regenerate vis components if necessary
    */
-  componentWillReceiveProps(nextProps) {
+  componentWillUpdate(nextProps) {
     // regenerate the vis components if the relevant props change
     this.visComponents = this.makeVisComponents(nextProps);
   }

--- a/src/components/LineChart/LineChartWithCounts.jsx
+++ b/src/components/LineChart/LineChartWithCounts.jsx
@@ -47,9 +47,9 @@ export default class LineChartWithCounts extends PureComponent {
   }
 
   /**
-   * When new props are received, regenerate vis components if necessary
+   * When new component is updating, regenerate vis components if necessary
    */
-  componentWillReceiveProps(nextProps) {
+  componentWillUpdate(nextProps) {
     // regenerate the vis components if the relevant props change
     this.visComponents = this.makeSharedVisComponents(nextProps);
   }

--- a/src/components/LineChartSmallMult/LineChartSmallMult.jsx
+++ b/src/components/LineChartSmallMult/LineChartSmallMult.jsx
@@ -55,9 +55,9 @@ export default class LineChartSmallMult extends PureComponent {
   }
 
   /**
-   * When new props are received, regenerate vis components if necessary
+   * When new component is updating, regenerate vis components if necessary
    */
-  componentWillReceiveProps(nextProps) {
+  componentWillUpdate(nextProps) {
     // regenerate the vis components if the relevant props change
     this.visComponents = this.makeVisComponents(nextProps);
   }

--- a/src/components/LineChartSmallMult/LineChartSmallMult.jsx
+++ b/src/components/LineChartSmallMult/LineChartSmallMult.jsx
@@ -170,11 +170,9 @@ export default class LineChartSmallMult extends PureComponent {
           .defined(d => d[metrics[yIndex].dataKey] != null)
           .accessData(d => d.results)
           .lineStyles({
-            stroke: (d, i) => {
-              // first element is baseline value
-              return (showBaseline && i === 0) ? '#aaa' : color(d.meta.client_asn_number);
-            },
-            'stroke-width': 1.5,
+            // first element is baseline value
+            stroke: (d, i) => ((showBaseline && i === 0) ? '#bbb' : color(d.meta.client_asn_number)),
+            'stroke-width': (d, i) => ((showBaseline && i === 0) ? 1 : 1.5),
           })
       );
     }
@@ -217,7 +215,7 @@ export default class LineChartSmallMult extends PureComponent {
    * Iterates through data, using line generators to update charts.
    */
   updateCharts() {
-    const { series, lineGens, metrics, showBaseline } = this.visComponents;
+    const { series, lineGens, metrics, showBaseline, chartHeight, xScale } = this.visComponents;
 
     series.forEach((s, sIndex) => {
       metrics.forEach((metric, keyIndex) => {
@@ -233,6 +231,16 @@ export default class LineChartSmallMult extends PureComponent {
           data.unshift(series[0]);
         }
 
+        // add in axis line
+        let axisLine = chart.select('.axis-line');
+        if (axisLine.empty()) {
+          axisLine = chart.append('line').attr('class', 'axis-line');
+        }
+        axisLine
+          .attr('x1', xScale.range()[0])
+          .attr('x2', xScale.range()[1])
+          .attr('y1', chartHeight + 3)
+          .attr('y2', chartHeight + 3);
 
         // BIND
         const binding = chart.selectAll('g').data(data);

--- a/src/components/LineChartSmallMult/LineChartSmallMult.scss
+++ b/src/components/LineChartSmallMult/LineChartSmallMult.scss
@@ -10,4 +10,8 @@
     font-size: 0.8em;
   }
 
+  .axis-line {
+    stroke: #ccc;
+    stroke-width: 1px;
+  }
 }

--- a/src/containers/LocationPage/LocationPage.jsx
+++ b/src/containers/LocationPage/LocationPage.jsx
@@ -59,6 +59,7 @@ function mapStateToProps(state, propsWithUrl) {
     locationTimeSeries: LocationPageSelectors.getLocationTimeSeries(state, propsWithUrl),
     timeSeriesStatus: LocationPageSelectors.getTimeSeriesStatus(state, propsWithUrl),
     clientIspTimeSeries: LocationPageSelectors.getLocationClientIspTimeSeries(state, propsWithUrl),
+    locationAndClientIspTimeSeries: LocationPageSelectors.getLocationAndClientIspTimeSeries(state, propsWithUrl),
     highlightHourly: LocationPageSelectors.getHighlightHourly(state, propsWithUrl),
     summary: LocationPageSelectors.getSummaryData(state, propsWithUrl),
   };
@@ -75,6 +76,7 @@ class LocationPage extends PureComponent {
     location: PropTypes.object, // route location
     locationId: PropTypes.string,
     locationInfo: PropTypes.object,
+    locationAndClientIspTimeSeries: PropTypes.array,
     locationTimeSeries: PropTypes.object,
     selectedClientIspIds: PropTypes.array,
     selectedClientIspInfo: PropTypes.array,
@@ -384,11 +386,8 @@ class LocationPage extends PureComponent {
   }
 
   renderCompareMetrics() {
-    const { timeSeriesStatus, locationTimeSeries, clientIspTimeSeries } = this.props;
-    let series = [];
-    if (locationTimeSeries) {
-      series = [locationTimeSeries].concat(clientIspTimeSeries);
-    }
+    const { timeSeriesStatus, locationAndClientIspTimeSeries } = this.props;
+
     const chartId = 'providers-small-mult';
     return (
       <div className="subsection">
@@ -398,7 +397,7 @@ class LocationPage extends PureComponent {
         <StatusWrapper status={timeSeriesStatus}>
           <LineChartSmallMult
             id={chartId}
-            series={series}
+            series={locationAndClientIspTimeSeries}
             width={800}
             xKey="date"
             metrics={metrics}

--- a/src/redux/locationPage/selectors.js
+++ b/src/redux/locationPage/selectors.js
@@ -87,18 +87,28 @@ function getLocationSelectedClientIspIds(state, props) {
   return props.selectedClientIspIds;
 }
 
+
+/**
+ * Input selector to get the client ISP map for a location
+ */
+function getLocationClientIsps(state, props) {
+  return getLocation(state, props).clientIsps;
+}
+
+
 // ----------------------
 // Selectors
 // ----------------------
+
 /**
  * Inflates clientIspIds into clientIsp values and returns
  * selected clientIsps
  */
 export const getLocationSelectedClientIsps = createSelector(
-  getLocation, getLocationSelectedClientIspIds,
-  (location, selectedIds) => {
+  getLocationClientIsps, getLocationSelectedClientIspIds,
+  (clientIsps, selectedIds) => {
     if (selectedIds) {
-      const selected = selectedIds.map(id => location.clientIsps[id]).filter(d => d != null);
+      const selected = selectedIds.map(id => clientIsps[id]).filter(d => d != null);
       return selected;
     }
     return [];
@@ -127,14 +137,6 @@ export const getLocationClientIspTimeSeriesObjects = createSelector(
     }
 
     return clientIsps.map(clientIsp => clientIsp.time.timeSeries);
-
-    // const timeSeriesObjects = clientIsps.map(clientIsp => {
-    //   const clientIspId = clientIsp.meta.client_asn_number;
-    //   const locationClientIsp = location.time.clientIsps[clientIspId];
-    //   return locationClientIsp && locationClientIsp.timeSeries;
-    // });
-
-    // return timeSeriesObjects;
   }
 );
 
@@ -170,6 +172,27 @@ export const getLocationClientIspTimeSeriesStatus = createSelector(
 export const getTimeSeriesStatus = createSelector(
   getLocationClientIspTimeSeriesStatus, getLocationTimeSeriesStatus,
   (ispStatus, locationStatus) => mergeStatuses(ispStatus, locationStatus));
+
+
+/**
+ * Selector to get the location+client ISP time series data
+ * for the selected client ISPs AND for the location all ine one array.
+ */
+export const getLocationAndClientIspTimeSeries = createSelector(
+  getLocationClientIspTimeSeries, getLocationTimeSeries,
+  (clientIspTimeSeries = [], locationTimeSeries) => {
+    let result = [];
+    if (locationTimeSeries) {
+      result.push(locationTimeSeries);
+    }
+
+    if (clientIspTimeSeries) {
+      result = result.concat(clientIspTimeSeries);
+    }
+
+    return result;
+  }
+);
 
 
 /**

--- a/src/url/tests/UrlHandler-test.js
+++ b/src/url/tests/UrlHandler-test.js
@@ -29,6 +29,42 @@ describe('url', () => {
         expect(result).to.deep.equal(expectedOutput);
       });
 
+      it('reuses cached values', () => {
+        const config = {
+          myArray: { type: 'array' },
+          myObject: { type: 'object' },
+          myArray2: { type: 'array' },
+        };
+
+        const query = {
+          myArray: '1_2_3',
+          myObject: 'a-1_b-2',
+          myArray2: '3_4_5',
+        };
+        const urlHandler = new UrlHandler(config);
+
+        const expectedOutput = {
+          myArray: ['1', '2', '3'],
+          myObject: { a: '1', b: '2' },
+          myArray2: ['3', '4', '5'],
+        };
+
+        const result = urlHandler.decodeQuery(query);
+        expect(result).to.deep.equal(expectedOutput);
+
+        const query2 = {
+          myArray: '1_2_3',
+          myObject: 'a-1_b-2',
+          myArray2: '4_5_6',
+        };
+
+        const result2 = urlHandler.decodeQuery(query2);
+        expect(result2.myArray).to.equal(result.myArray);
+        expect(result2.myObject).to.equal(result.myObject);
+        expect(result2.myArray2).to.not.equal(result.myArray2);
+        expect(result2.myArray2).to.deep.equal(['4', '5', '6']);
+      });
+
       it('ignores query params not in config', () => {
         const config = {
           myStr: { type: 'string', defaultValue: 'download', urlKey: 'str' },

--- a/src/url/tests/urlConnect-test.jsx
+++ b/src/url/tests/urlConnect-test.jsx
@@ -88,6 +88,59 @@ describe('url', () => {
 
         shallow(<WrappedMyComponent store={store} other={1} other2={2} />);
       });
+
+      it('decodes only if the value has changed, otherwise reuses previous', () => {
+        const store = createStore(() => ({}));
+
+        const config = {
+          myArray: { type: 'array' },
+          myObject: { type: 'object' },
+          myArray2: { type: 'array' },
+        };
+        const urlHandler = new UrlHandler(config);
+
+        const query = {
+          myArray: '1_2_3',
+          myObject: 'a-1_b-2',
+          myArray2: '3_4_5',
+        };
+
+        const location = { query };
+
+        // test that mapStateToProps has URL props in there
+        let myArrayPrev;
+        let myObjectPrev;
+        let myArray2Prev;
+
+        function mapStateToProps(state, props) {
+          expect(props).to.contain.keys('myArray', 'myObject');
+          expect(props.myArray).to.deep.equal(['1', '2', '3']);
+          expect(props.myObject).to.deep.equal({ a: '1', b: '2' });
+
+          if (myArrayPrev) {
+            expect(props.myArray).to.equal(myArrayPrev);
+          }
+          if (myObjectPrev) {
+            expect(props.myObject).to.equal(myObjectPrev);
+          }
+          if (myArray2Prev) {
+            expect(props.myArray2).to.not.equal(myArray2Prev);
+            expect(props.myArray2).to.deep.equal(['4', '5', '6']);
+            expect(myArray2Prev).to.deep.equal(['3', '4', '5']);
+          }
+
+          myArrayPrev = props.myArray;
+          myObjectPrev = props.myObject;
+          myArray2Prev = props.myArray2;
+
+          return props;
+        }
+
+        const WrappedMyComponent = urlConnect(urlHandler, mapStateToProps)(MyComponent);
+
+        const wrapped = mount(<WrappedMyComponent store={store} location={location} />);
+        wrapped.setProps({ location: { query: { ...query, myArray2: '4_5_6' } } });
+      });
     });
 
     describe('dispatch', () => {

--- a/src/url/urlConnect.jsx
+++ b/src/url/urlConnect.jsx
@@ -29,7 +29,8 @@ export default function urlConnect(urlHandler, mapStateToProps, mapDispatchToPro
 
   // otherwise, add in query params to mapStateToProps
   function mapStateToPropsWithUrl(state, props) {
-    const urlQueryParams = (props.location && urlHandler.decodeQuery(props.location.query)) || {};
+    const currentQuery = (props.location && props.location.query) || {};
+    const urlQueryParams = urlHandler.decodeQuery(currentQuery);
     const urlParams = props.params || {};
 
     const propsWithUrl = {

--- a/src/utils/debug.js
+++ b/src/utils/debug.js
@@ -1,0 +1,67 @@
+/**
+ * Taken from React's PureRenderMixin - https://github.com/francoislaberge/pure-render-mixin/blob/master/src/shallow-equal.js
+ * Performs equality by iterating through keys on an object and returning
+ * false when any key has values which are not strictly equal between
+ * objA and objB. Returns true when the values of all keys are strictly equal.
+ *
+ * @return {Boolean}
+ */
+export function shallowEqual(objA, objB, excludeKeys) {
+  if (objA === objB) {
+    return true;
+  }
+
+  if (typeof objA !== 'object' || objA === null ||
+      typeof objB !== 'object' || objB === null) {
+    return false;
+  }
+
+  let keysA = Object.keys(objA);
+  let keysB = Object.keys(objB);
+
+  if (excludeKeys) {
+    keysA = keysA.filter(key => excludeKeys.indexOf(key) === -1);
+    keysB = keysB.filter(key => excludeKeys.indexOf(key) === -1);
+  }
+
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
+
+  // Test for A's keys different from B.
+  const bHasOwnProperty = Object.prototype.hasOwnProperty.bind(objB);
+  for (let i = 0; i < keysA.length; i++) {
+    if (!bHasOwnProperty(keysA[i]) || objA[keysA[i]] !== objB[keysA[i]]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export const shallowEquals = shallowEqual;
+
+/**
+ * Logs and returns an array showing the places where shallow equals failed or the string "equal"
+ */
+export function shallowEqualDebug(objA, objB) {
+  let result;
+  if (shallowEqual(objA, objB)) {
+    result = 'equal';
+  } else {
+    result = Object.keys(objA)
+      .filter(key => objA[key] !== objB[key])
+      .map(key => ({ key, a: objA[key], b: objB[key] }))
+      .reduce((acc, elem) => {
+        acc.push(elem.key);
+        acc.push(elem.a);
+        acc.push(elem.b);
+        return acc;
+      }, []);
+  }
+
+  console.log('shallowEqualDebug:', result);
+  return result;
+}
+
+export const shallowEqualsDebug = shallowEqualDebug;


### PR DESCRIPTION
- Improved/created selectors to refresh only when changes take place
- Updated URL Connect and URL Handler to cache results to prevent re-decoding into new arrays and objects, which caused re-renders to happen
- And for fun, added in an axis line to small mults.
![image](https://cloud.githubusercontent.com/assets/793847/18287457/399f6f98-7445-11e6-8f0d-6a09bcedfeec.png)
