### PR TITLE
Get hourly data for selected ISPs added to page

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -80,7 +80,8 @@ export function getLocationHourly(timeAggregation, locationId, options = {}) {
 }
 
 /**
- * Get data for a client ISP in a location in a given time aggregation
+ * Get time series data for a client ISP in a location in a given time aggregation
+ *
  * @param {String} timeAggregation The aggregation of the data (one of day, month,
  *    year, day_hour, month_hour, year_hour)
  * @param {String} locationId The location to query (e.g., nauswaseattle)
@@ -93,6 +94,24 @@ export function getLocationClientIspTimeSeries(timeAggregation, locationId, clie
 
   return get(`/locations/${locationId}/time/${timeAggregation}/clientisps/${clientIspId}/metrics`, { params })
     .then(transform(transformTimeSeries));
+}
+
+
+/**
+ * Get hourly data for a client ISP in a location in a given time aggregation
+ *
+ * @param {String} timeAggregation The aggregation of the data (one of day, month,
+ *    year, day_hour, month_hour, year_hour)
+ * @param {String} locationId The location to query (e.g., nauswaseattle)
+ * @param {String} clientIspId The AS number of the ISP (e.g., AS7922)
+ * @param {Object} options with startDate and endDate moment objects
+ * @return {Promise} A promise after the get request was made
+ */
+export function getLocationClientIspHourly(timeAggregation, locationId, clientIspId, options = {}) {
+  const params = getDateRangeParams(timeAggregation, options);
+
+  return get(`/locations/${locationId}/time/${timeAggregation}_hour/clientisps/${clientIspId}/metrics`, { params })
+    .then(transform(transformHourly));
 }
 
 /**

--- a/src/components/HourChart/HourChart.jsx
+++ b/src/components/HourChart/HourChart.jsx
@@ -264,7 +264,7 @@ export default class HourChart extends PureComponent {
         // ENTER
         const entering = hourBinding.enter()
           .append('circle')
-          .style('fill', 'rgb(163, 163, 237)');
+          .style('fill', 'rgb(34, 121, 181)');
 
         // ENTER + UPDATE
         hourBinding

--- a/src/containers/LocationPage/LocationPage.jsx
+++ b/src/containers/LocationPage/LocationPage.jsx
@@ -50,18 +50,18 @@ const urlHandler = new UrlHandler(urlQueryConfig, browserHistory);
 function mapStateToProps(state, propsWithUrl) {
   return {
     ...propsWithUrl,
-    locationInfo: LocationPageSelectors.getLocationInfo(state, propsWithUrl),
-    viewMetric: LocationPageSelectors.getViewMetric(state, propsWithUrl),
-    topClientIsps: LocationPageSelectors.getLocationTopClientIsps(state, propsWithUrl),
-    selectedClientIspInfo: LocationPageSelectors.getLocationSelectedClientIspInfo(state, propsWithUrl),
-    locationHourly: LocationPageSelectors.getLocationHourly(state, propsWithUrl),
-    hourlyStatus: LocationPageSelectors.getLocationHourlyStatus(state, propsWithUrl),
-    locationTimeSeries: LocationPageSelectors.getLocationTimeSeries(state, propsWithUrl),
-    timeSeriesStatus: LocationPageSelectors.getTimeSeriesStatus(state, propsWithUrl),
     clientIspTimeSeries: LocationPageSelectors.getLocationClientIspTimeSeries(state, propsWithUrl),
-    locationAndClientIspTimeSeries: LocationPageSelectors.getLocationAndClientIspTimeSeries(state, propsWithUrl),
     highlightHourly: LocationPageSelectors.getHighlightHourly(state, propsWithUrl),
+    hourlyStatus: LocationPageSelectors.getLocationHourlyStatus(state, propsWithUrl),
+    locationInfo: LocationPageSelectors.getLocationInfo(state, propsWithUrl),
+    locationAndClientIspTimeSeries: LocationPageSelectors.getLocationAndClientIspTimeSeries(state, propsWithUrl),
+    locationHourly: LocationPageSelectors.getLocationHourly(state, propsWithUrl),
+    locationTimeSeries: LocationPageSelectors.getLocationTimeSeries(state, propsWithUrl),
+    selectedClientIspInfo: LocationPageSelectors.getLocationSelectedClientIspInfo(state, propsWithUrl),
     summary: LocationPageSelectors.getSummaryData(state, propsWithUrl),
+    timeSeriesStatus: LocationPageSelectors.getTimeSeriesStatus(state, propsWithUrl),
+    topClientIsps: LocationPageSelectors.getLocationTopClientIsps(state, propsWithUrl),
+    viewMetric: LocationPageSelectors.getViewMetric(state, propsWithUrl),
   };
 }
 

--- a/src/containers/LocationPage/LocationPage.jsx
+++ b/src/containers/LocationPage/LocationPage.jsx
@@ -54,7 +54,7 @@ function mapStateToProps(state, propsWithUrl) {
     viewMetric: LocationPageSelectors.getViewMetric(state, propsWithUrl),
     topClientIsps: LocationPageSelectors.getLocationTopClientIsps(state, propsWithUrl),
     selectedClientIspInfo: LocationPageSelectors.getLocationSelectedClientIspInfo(state, propsWithUrl),
-    hourly: LocationPageSelectors.getLocationHourly(state, propsWithUrl),
+    locationHourly: LocationPageSelectors.getLocationHourly(state, propsWithUrl),
     hourlyStatus: LocationPageSelectors.getLocationHourlyStatus(state, propsWithUrl),
     locationTimeSeries: LocationPageSelectors.getLocationTimeSeries(state, propsWithUrl),
     timeSeriesStatus: LocationPageSelectors.getTimeSeriesStatus(state, propsWithUrl),
@@ -71,12 +71,12 @@ class LocationPage extends PureComponent {
     dispatch: PropTypes.func,
     endDate: momentPropTypes.momentObj,
     highlightHourly: PropTypes.object,
-    hourly: PropTypes.object,
     hourlyStatus: PropTypes.string,
     location: PropTypes.object, // route location
+    locationAndClientIspTimeSeries: PropTypes.array,
+    locationHourly: PropTypes.object,
     locationId: PropTypes.string,
     locationInfo: PropTypes.object,
-    locationAndClientIspTimeSeries: PropTypes.array,
     locationTimeSeries: PropTypes.object,
     selectedClientIspIds: PropTypes.array,
     selectedClientIspInfo: PropTypes.array,
@@ -409,10 +409,10 @@ class LocationPage extends PureComponent {
   }
 
   renderProvidersByHour() {
-    const { hourly, hourlyStatus, highlightHourly, locationId, viewMetric } = this.props;
+    const { locationHourly, hourlyStatus, highlightHourly, locationId, viewMetric } = this.props;
     const extentKey = this.extentKey(viewMetric);
     const chartId = 'providers-hourly';
-    const chartData = hourly && hourly.results;
+    const chartData = locationHourly && locationHourly.results;
 
     return (
       <div className="subsection">
@@ -421,14 +421,14 @@ class LocationPage extends PureComponent {
         </header>
         <StatusWrapper status={hourlyStatus}>
           <HourChartWithCounts
-            data={hourly && hourly.results}
+            data={locationHourly && locationHourly.results}
             height={400}
             highlightPoint={highlightHourly}
             id={chartId}
             onHighlightPoint={this.onHighlightHourly}
             threshold={30}
             width={800}
-            yExtent={hourly && hourly.extents[extentKey]}
+            yExtent={locationHourly && locationHourly.extents[extentKey]}
             yKey={viewMetric.dataKey}
           />
           <ChartExportControls

--- a/src/containers/LocationPage/LocationPage.jsx
+++ b/src/containers/LocationPage/LocationPage.jsx
@@ -151,10 +151,11 @@ class LocationPage extends PureComponent {
     // fetch data for selected Client ISPs
     if (selectedClientIspIds) {
       selectedClientIspIds.forEach(clientIspId => {
-        dispatch(
-          LocationsActions.fetchClientIspLocationTimeSeriesIfNeeded(timeAggregation, locationId, clientIspId, options)
-        );
         dispatch(LocationsActions.fetchClientIspInfoIfNeeded(locationId, clientIspId));
+        dispatch(LocationsActions.fetchClientIspLocationTimeSeriesIfNeeded(timeAggregation, locationId,
+          clientIspId, options));
+        dispatch(LocationsActions.fetchClientIspLocationHourlyIfNeeded(timeAggregation, locationId,
+          clientIspId, options));
       });
     }
   }

--- a/src/containers/LocationPage/LocationPage.jsx
+++ b/src/containers/LocationPage/LocationPage.jsx
@@ -411,7 +411,7 @@ class LocationPage extends PureComponent {
   }
 
   renderProvidersByHour() {
-    const { locationHourly, clientIspHourly, hourlyStatus, highlightHourly, locationId, viewMetric } = this.props;
+    const { locationHourly, hourlyStatus, highlightHourly, locationId, viewMetric } = this.props;
     const extentKey = this.extentKey(viewMetric);
     const chartId = 'providers-hourly';
     const chartData = locationHourly && locationHourly.results;
@@ -421,29 +421,27 @@ class LocationPage extends PureComponent {
         <header>
           <h3>By Hour, Median download speeds</h3>
         </header>
-        <StatusWrapper status={hourlyStatus}>
-          <HourChartWithCounts
-            data={locationHourly && locationHourly.results}
-            height={400}
-            highlightPoint={highlightHourly}
-            id={chartId}
-            onHighlightPoint={this.onHighlightHourly}
-            threshold={30}
-            width={800}
-            yExtent={locationHourly && locationHourly.extents[extentKey]}
-            yKey={viewMetric.dataKey}
-          />
-          <ChartExportControls
-            chartId={chartId}
-            data={chartData}
-            filename={`${locationId}_${viewMetric.value}_${chartId}`}
-          />
-        </StatusWrapper>
-        <div style={{ clear: 'both' /* TODO: fix this */ }}>
-          <Row>
-            {this.renderClientIspsByHour()}
-          </Row>
+        <div className="clearfix">
+          <StatusWrapper status={hourlyStatus}>
+            <HourChartWithCounts
+              data={locationHourly && locationHourly.results}
+              height={400}
+              highlightPoint={highlightHourly}
+              id={chartId}
+              onHighlightPoint={this.onHighlightHourly}
+              threshold={30}
+              width={800}
+              yExtent={locationHourly && locationHourly.extents[extentKey]}
+              yKey={viewMetric.dataKey}
+            />
+            <ChartExportControls
+              chartId={chartId}
+              data={chartData}
+              filename={`${locationId}_${viewMetric.value}_${chartId}`}
+            />
+          </StatusWrapper>
         </div>
+        {this.renderClientIspsByHour()}
       </div>
     );
   }

--- a/src/redux/locationPage/selectors.js
+++ b/src/redux/locationPage/selectors.js
@@ -235,3 +235,46 @@ export const getSummaryData = createSelector(
     return results;
   }
 );
+
+/**
+ * Selector to get the data objects for location+client ISP hourly data
+ * for the selected client ISPs
+ */
+export const getLocationClientIspHourlyObjects = createSelector(
+  getLocationSelectedClientIsps,
+  (clientIsps) => {
+    if (!clientIsps) {
+      return undefined;
+    }
+
+    return clientIsps.map(clientIsp => clientIsp.time.hourly);
+  }
+);
+
+/**
+ * Selector to get the location+client ISP hourly data
+ * for the selected client ISPs
+ */
+export const getLocationClientIspHourly = createSelector(
+  getLocationClientIspHourlyObjects,
+  (hourlyObjects) => {
+    if (!hourlyObjects) {
+      return undefined;
+    }
+
+    return hourlyObjects.map(hourly => hourly && hourly.data)
+      .filter(hourly => hourly != null);
+  }
+);
+
+/**
+ * Selector to get the status of the location+client ISP hourly data
+ * for the selected client ISPs
+ */
+export const getLocationClientIspHourlyStatus = createSelector(
+  getLocationClientIspHourlyObjects,
+  (hourlyObjects) => status(hourlyObjects));
+
+
+
+

--- a/src/redux/locations/actions.js
+++ b/src/redux/locations/actions.js
@@ -168,6 +168,56 @@ export const shouldFetchClientIspLocationTimeSeries = clientIspLocationTimeSerie
 export const fetchClientIspLocationTimeSeries = clientIspLocationTimeSeries.fetch;
 export const fetchClientIspLocationTimeSeriesIfNeeded = clientIspLocationTimeSeries.fetchIfNeeded;
 
+
+// ---------------------
+// Fetch Client ISP in Location Hourly
+// ---------------------
+const clientIspLocationHourly = createFetchAction({
+  typePrefix: 'location/',
+  key: 'CLIENT_ISP_HOURLY',
+  args: ['timeAggregation', 'locationId', 'clientIspId', 'options'],
+  shouldFetch(state, timeAggregation, locationId, clientIspId, options) {
+    const locationState = state.locations[locationId];
+    if (!locationState) {
+      return true;
+    }
+
+    const clientIspState = locationState.clientIsps[clientIspId];
+    if (!clientIspState) {
+      return true;
+    }
+    const clientIspTimeState = clientIspState.time;
+
+    // if we don't have this time aggregation, we should fetch it
+    if (clientIspTimeState.hourly.timeAggregation !== timeAggregation) {
+      return true;
+    }
+
+    if (options.startDate && !options.startDate.isSame(clientIspTimeState.hourly.startDate, timeAggregation)) {
+      return true;
+    }
+
+    if (options.endDate && !options.endDate.isSame(clientIspTimeState.hourly.endDate, timeAggregation)) {
+      return true;
+    }
+
+    // only fetch if it isn't fetching/already fetched
+    return !(clientIspTimeState.hourly.isFetched ||
+      clientIspTimeState.hourly.isFetching);
+  },
+
+  promise(timeAggregation, locationId, clientIspId, options) {
+    return api => api.getLocationClientIspHourly(timeAggregation, locationId, clientIspId, options);
+  },
+});
+export const FETCH_CLIENT_ISP_HOURLY = clientIspLocationHourly.types.fetch;
+export const FETCH_CLIENT_ISP_HOURLY_SUCCESS = clientIspLocationHourly.types.success;
+export const FETCH_CLIENT_ISP_HOURLY_FAIL = clientIspLocationHourly.types.fail;
+export const shouldFetchClientIspLocationHourly = clientIspLocationHourly.shouldFetch;
+export const fetchClientIspLocationHourly = clientIspLocationHourly.fetch;
+export const fetchClientIspLocationHourlyIfNeeded = clientIspLocationHourly.fetchIfNeeded;
+
+
 // ---------------------
 // Fetch Location Info
 // ---------------------

--- a/src/redux/locations/initialState.js
+++ b/src/redux/locations/initialState.js
@@ -51,5 +51,9 @@ export const initialClientIspState = {
       isFetching: false,
       isFetched: false,
     },
+    hourly: {
+      isFetching: false,
+      isFetched: false,
+    },
   },
 };

--- a/src/redux/locations/reducer.js
+++ b/src/redux/locations/reducer.js
@@ -17,6 +17,9 @@ function locations(state = initialState, action = {}) {
     case Actions.FETCH_CLIENT_ISP_TIME_SERIES:
     case Actions.FETCH_CLIENT_ISP_TIME_SERIES_SUCCESS:
     case Actions.FETCH_CLIENT_ISP_TIME_SERIES_FAIL:
+    case Actions.FETCH_CLIENT_ISP_HOURLY:
+    case Actions.FETCH_CLIENT_ISP_HOURLY_SUCCESS:
+    case Actions.FETCH_CLIENT_ISP_HOURLY_FAIL:
     case Actions.FETCH_TOP_CLIENT_ISPS:
     case Actions.FETCH_TOP_CLIENT_ISPS_SUCCESS:
     case Actions.FETCH_TOP_CLIENT_ISPS_FAIL:

--- a/src/redux/locations/reducers/clientIsp.js
+++ b/src/redux/locations/reducers/clientIsp.js
@@ -37,7 +37,38 @@ function timeSeries(state = initialClientIspState.time.timeSeries, action = {}) 
   }
 }
 
-const time = combineReducers({ timeSeries });
+function hourly(state = initialClientIspState.time.hourly, action = {}) {
+  switch (action.type) {
+    case Actions.FETCH_CLIENT_ISP_HOURLY:
+      return {
+        data: state.data,
+        timeAggregation: action.timeAggregation,
+        startDate: action.options.startDate,
+        endDate: action.options.endDate,
+        isFetching: true,
+        isFetched: false,
+      };
+    case Actions.FETCH_CLIENT_ISP_HOURLY_SUCCESS:
+      return {
+        data: action.result,
+        timeAggregation: action.timeAggregation,
+        startDate: action.options.startDate,
+        endDate: action.options.endDate,
+        isFetching: false,
+        isFetched: true,
+      };
+    case Actions.FETCH_CLIENT_ISP_HOURLY_FAIL:
+      return {
+        isFetching: false,
+        isFetched: false,
+        error: action.error,
+      };
+    default:
+      return state;
+  }
+}
+
+const time = combineReducers({ timeSeries, hourly });
 
 
 // reducer for location+client ISP info

--- a/src/redux/locations/reducers/location.js
+++ b/src/redux/locations/reducers/location.js
@@ -158,6 +158,9 @@ function clientIsps(state = initialLocationState.clientIsps, action = {}) {
     case Actions.FETCH_CLIENT_ISP_TIME_SERIES:
     case Actions.FETCH_CLIENT_ISP_TIME_SERIES_SUCCESS:
     case Actions.FETCH_CLIENT_ISP_TIME_SERIES_FAIL:
+    case Actions.FETCH_CLIENT_ISP_HOURLY:
+    case Actions.FETCH_CLIENT_ISP_HOURLY_SUCCESS:
+    case Actions.FETCH_CLIENT_ISP_HOURLY_FAIL:
     case Actions.FETCH_CLIENT_ISP_INFO:
     case Actions.FETCH_CLIENT_ISP_INFO_SUCCESS:
     case Actions.FETCH_CLIENT_ISP_INFO_FAIL:


### PR DESCRIPTION
This PR gets hourly data for client ISPs in the store and available to LocationPage. Quickly set up rendering multiple charts but they need to be cleaned up in the future- this is just a start. They do not have labels or different colors nor do they share axis extents.

![image](https://cloud.githubusercontent.com/assets/793847/18291969/d9ce69b6-7458-11e6-8938-275d8fc943b0.png)
