### PR TITLE
Separate location data out to be a bottom data row in the summary data table

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "react-router-redux": "^4.0.0",
     "react-router-scroll": "^0.3.1",
     "react-select": "^1.0.0-beta14",
-    "react-taco-table": "^0.3.2",
+    "react-taco-table": "^0.4.0",
     "react-transform-hmr": "^1.0.1",
     "redux": "^3.0.4",
     "redux-devtools": "^3.3.1",

--- a/src/components/SummaryTable/SummaryTable.jsx
+++ b/src/components/SummaryTable/SummaryTable.jsx
@@ -35,15 +35,16 @@ const columns = [
  */
 export default class SummaryData extends PureComponent {
   static propTypes = {
+    bottomData: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
     data: PropTypes.array,
   }
 
   render() {
-    const { data } = this.props;
+    const { data, bottomData } = this.props;
 
     return (
       <div className="SummaryTable">
-        <TacoTable columns={columns} data={data} />
+        <TacoTable columns={columns} data={data} bottomData={bottomData} />
       </div>
     );
   }

--- a/src/containers/LocationPage/LocationPage.jsx
+++ b/src/containers/LocationPage/LocationPage.jsx
@@ -517,7 +517,7 @@ class LocationPage extends PureComponent {
 
   renderFixedSummaryData() {
     const { summary = {} } = this.props;
-    const { lastYear } = summary;
+    const { lastYear = {} } = summary;
 
     return (
       <div className="subsection">
@@ -525,7 +525,7 @@ class LocationPage extends PureComponent {
           <h3>Summary Data</h3>
         </header>
         <h4>Last Year</h4>
-        <SummaryTable data={lastYear} />
+        <SummaryTable data={lastYear.clientIspsData} bottomData={lastYear.locationData} />
       </div>
     );
   }

--- a/src/redux/locationPage/selectors.js
+++ b/src/redux/locationPage/selectors.js
@@ -197,6 +197,8 @@ export const getLocationAndClientIspTimeSeries = createSelector(
 
 /**
  * Selector to get the summary data for the location and related ISPs
+ * @return {Object} A key for each type of fixed data
+ * Sample: { lastYear: { locationData: {}, clientIspsData: [] }}
  */
 export const getSummaryData = createSelector(
   getLocationInfo, getLocationFixed, getLocationSelectedClientIsps,
@@ -209,7 +211,7 @@ export const getSummaryData = createSelector(
       selectedClientIsps = [];
     }
 
-    // gropu all the `lastYear`, `lastweek`, etc together
+    // group all the `lastYear`, `lastweek`, etc together
     const results = Object.keys(locationFixed).reduce((grouped, key) => {
       const locationData = {
         ...locationFixed[key],
@@ -227,7 +229,7 @@ export const getSummaryData = createSelector(
         };
       });
 
-      grouped[key] = [locationData, ...clientIspsData];
+      grouped[key] = { locationData, clientIspsData };
 
       return grouped;
     }, {});


### PR DESCRIPTION
This adds a bottom data row to #12.

Note this requires updating react-taco-table to 0.4.0, so you'll have to `npm install` 💯 

Produces:
![image](https://cloud.githubusercontent.com/assets/793847/18328880/087cd89e-751f-11e6-9bbd-430f656655fb.png)
