### PR TITLE
Experiment with Unique colors for ISPs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "d3-array": "^1.0.1",
     "d3-axis": "^1.0.3",
     "d3-collection": "^1.0.1",
+    "d3-color": "^1.0.1",
     "d3-interpolate-path": "^1.0.1",
     "d3-line-chunked": "^1.2.0",
     "d3-scale": "^1.0.3",

--- a/src/components/IspSelect/IspSelect.jsx
+++ b/src/components/IspSelect/IspSelect.jsx
@@ -4,6 +4,8 @@ import Select from 'react-select';
 
 import { Icon } from '../../components';
 
+import { colorsFor } from '../../utils/color';
+
 import '../../assets/react-select.scss';
 import './IspSelect.scss';
 
@@ -75,9 +77,10 @@ export default class IspSelect extends PureComponent {
    * Render individual isp name
    * @return {React.Component} active isps
    */
-  renderIsp(isp) {
+  renderIsp(isp, color) {
+    const style = { backgroundColor: color };
     return (
-      <div key={isp.client_asn_number} className="selected-isp">
+      <div key={isp.client_asn_number} className="selected-isp" style={style}>
         <span className="isp-label">{isp.client_asn_name}</span>
         <Icon
           name="close"
@@ -93,10 +96,11 @@ export default class IspSelect extends PureComponent {
    * @return {React.Component} active isps
    */
   renderSelectedIsps(selectedIsps) {
+    const colors = colorsFor(selectedIsps, (d) => d.client_asn_number);
     return (
       <div className="active-isps">
         {selectedIsps.map((selectedIsp, i) =>
-          this.renderIsp(selectedIsp, i)
+          this.renderIsp(selectedIsp, colors[selectedIsp.client_asn_number])
         )}
       </div>
     );

--- a/src/components/LineChart/LineChart.jsx
+++ b/src/components/LineChart/LineChart.jsx
@@ -1,6 +1,7 @@
 import React, { PureComponent, PropTypes } from 'react';
 import d3 from 'd3';
 import { multiExtent } from '../../utils/array';
+import { colorsFor } from '../../utils/color';
 
 import './LineChart.scss';
 
@@ -150,9 +151,9 @@ export default class LineChart extends PureComponent {
     }
 
     // initialize a color scale
-    const color = d3.scaleOrdinal(d3.schemeCategory10);
+    let colors = {};
     if (series) {
-      color.domain(d3.range(series.length));
+      colors = colorsFor(series, (d) => d.meta.client_asn_number);
     }
 
     // function to generate paths for each series
@@ -163,7 +164,7 @@ export default class LineChart extends PureComponent {
       .defined(d => d[yKey] != null)
       .accessData(d => d.results)
       .lineStyles({
-        stroke: (d, i) => color(i),
+        stroke: (d) => colors[d.meta.client_asn_number],
         'stroke-width': 1.5,
       });
 
@@ -187,7 +188,7 @@ export default class LineChart extends PureComponent {
     return {
       annotationLineChunked,
       annotationSeries,
-      color,
+      colors,
       height,
       innerHeight,
       innerMargin,

--- a/src/components/LineChartSmallMult/LineChartSmallMult.jsx
+++ b/src/components/LineChartSmallMult/LineChartSmallMult.jsx
@@ -1,6 +1,7 @@
 import React, { PureComponent, PropTypes } from 'react';
 import d3 from 'd3';
 import { multiExtent } from '../../utils/array';
+import { colorsFor } from '../../utils/color';
 
 import './LineChartSmallMult.scss';
 
@@ -153,9 +154,9 @@ export default class LineChartSmallMult extends PureComponent {
 
     // initialize a color scale
     // TODO: this should be moved out and shared among components.
-    const color = d3.scaleOrdinal(d3.schemeCategory10);
+    let colors = {};
     if (series) {
-      color.domain(series.map(s => s.meta.client_asn_number));
+      colors = colorsFor(series, (d) => d.meta.client_asn_number);
     }
 
     // create lineChunked generators for all ykeys
@@ -171,7 +172,7 @@ export default class LineChartSmallMult extends PureComponent {
           .accessData(d => d.results)
           .lineStyles({
             // first element is baseline value
-            stroke: (d, i) => ((showBaseline && i === 0) ? '#bbb' : color(d.meta.client_asn_number)),
+            stroke: (d, i) => ((showBaseline && i === 0) ? '#bbb' : colors[d.meta.client_asn_number]),
             'stroke-width': (d, i) => ((showBaseline && i === 0) ? 1 : 1.5),
           })
       );
@@ -185,7 +186,7 @@ export default class LineChartSmallMult extends PureComponent {
     return {
       // annotationLineChunked,
       annotationSeries,
-      color,
+      colors,
       height,
       innerHeight,
       innerMargin,

--- a/src/d3.js
+++ b/src/d3.js
@@ -13,6 +13,7 @@ import * as selection from 'd3-selection';
 import * as shape from 'd3-shape';
 import * as timeFormat from 'd3-time-format';
 import * as axis from 'd3-axis';
+import * as color from 'd3-color';
 import * as collection from 'd3-collection';
 import * as lineChunked from 'd3-line-chunked';
 import * as scaleInteractive from 'd3-scale-interactive';
@@ -24,6 +25,7 @@ export default Object.assign({},
   shape,
   timeFormat,
   axis,
+  color,
   lineChunked,
   transition,
   scaleInteractive,

--- a/src/utils/color.js
+++ b/src/utils/color.js
@@ -1,0 +1,105 @@
+
+import d3 from 'd3';
+import { mod } from './math';
+
+
+const HCL_COLORS = [
+  [58, 41.304, 34.656],
+  [298, 75.161, 42.059],
+  [137, 64.651, 58.731],
+  [328, 84.426, 53.029],
+  [120, 47.749, 58.34],
+  [311, 82.059, 43.205],
+  [98, 51.58, 57.183],
+  [313, 67.87, 28.574],
+  [64, 62.705, 58.549],
+  [284, 55.45, 55.61],
+  [37, 74.374, 52.407],
+  [304, 65.081, 55.232],
+  [127, 39.378, 37.807],
+  [340, 73.623, 55.366],
+  [165, 36.472, 56.113],
+  [359, 66.681, 52.232],
+  [269, 34.85, 55.85],
+  [39, 58.141, 37.967],
+  [297, 49.28, 31.17],
+  [77, 39.453, 52.82],
+  [321, 66.556, 56.371],
+  [37, 43.641, 57.443],
+  [304, 36.142, 30.132],
+  [14, 56.059, 50.812],
+  [309, 43.404, 55.378],
+  [15, 38.89, 30.752],
+  [333, 60.682, 40.155],
+  [345, 42.869, 60.46],
+  [335, 43.323, 26.682],
+  [345, 39.365, 43.355],
+];
+
+/**
+ * color for isps
+ */
+export function hashAsn(asnNumber, maxCount) {
+  if (!asnNumber) {
+    return 0;
+  }
+  const asn = +(asnNumber.replace(/\D+/g, ''));
+  return mod(asn, maxCount);
+}
+
+/**
+ * color for isps
+ */
+function varyColor(colors, overlaps) {
+  overlaps.forEach((overlap) => {
+    const length = overlap.values.length;
+    if (length > 1) {
+      let brightenToggle = true;
+      let k = 1.0;
+      let i = 1;
+      // Start at the 2nd overlapping index
+      for (i = 1; i < length; i++) {
+        const index = overlap.values[i].index;
+        colors[index] = (brightenToggle) ? colors[index].brighter(k) : colors[index].darker(k);
+        brightenToggle = !brightenToggle;
+        if (brightenToggle) {
+          k += 1.0;
+        }
+      }
+    }
+  });
+
+  return colors;
+}
+
+/**
+ * create an array of colors, one for each value in values
+ */
+export function extractColors(values, valueAccessor = d => d, hashFunction = hashAsn) {
+  const maxCount = HCL_COLORS.length;
+  const indexes = values.map((v, i) => ({ index: i, hash: hashFunction(valueAccessor(v), maxCount) }));
+
+  const colors = indexes.map((h) => d3.hcl(...HCL_COLORS[h.hash]));
+
+
+  const overlaps = d3.nest()
+    .key((d) => d.hash)
+    .entries(indexes);
+
+  const variedColors = varyColor(colors, overlaps);
+
+  return variedColors.map((c) => c.toString());
+}
+
+/**
+ * create an object with keys as values, mapped to colors
+ */
+export function colorsFor(values, valueAccessor = d => d, hashFunction = hashAsn) {
+  const colors = extractColors(values, valueAccessor, hashFunction);
+  const colorMap = {};
+  colors.forEach((color, index) => {
+    colorMap[valueAccessor(values[index])] = color;
+  });
+
+  return colorMap;
+}

--- a/src/utils/math.js
+++ b/src/utils/math.js
@@ -1,3 +1,12 @@
+
+/**
+ * Return modulo of a number
+ */
+export function mod(num, mod) {
+  const remain = num % mod;
+  return Math.floor(remain >= 0 ? remain : remain + mod);
+}
+
 /**
  * Helper function to make an accessor from a string or function.
  *

--- a/src/utils/tests/color-test.js
+++ b/src/utils/tests/color-test.js
@@ -1,0 +1,52 @@
+import d3 from 'd3';
+import { expect } from 'chai';
+import { hashAsn, colorsFor, extractColors } from '../color';
+
+
+describe('utils', () => {
+  describe('color', () => {
+    describe('hashAsn', () => {
+      it('hashes asn numbers', () => {
+        let asnum = 'AS123+';
+        let result = hashAsn(asnum, 100);
+        expect(result).to.equal(23);
+
+        asnum = 'AS99';
+        result = hashAsn(asnum, 100);
+        expect(result).to.equal(99);
+      });
+
+      it('hashes asn numbers', () => {
+      });
+    });
+
+    describe('extractColors', () => {
+      it('provides colors to asns', () => {
+        const asns = ['AS100', 'AS101', 'AS103'];
+        const colors = extractColors(asns);
+        expect(colors).to.deep.equal(['rgb(225, 69, 51)', 'rgb(141, 114, 227)', 'rgb(223, 70, 178)']);
+      });
+      it('does not duplicate colors', () => {
+        const asns = ['AS100', 'AS100', 'AS100', 'AS100'];
+        const colors = extractColors(asns);
+        expect(colors.length).to.equal(asns.length);
+        const uniqueColors = d3.set(colors).values();
+        expect(colors.length).to.equal(uniqueColors.length);
+      });
+    });
+
+    describe('colorsFor', () => {
+      it('provides colors to asns', () => {
+        const asns = ['AS100', 'AS101', 'AS103'];
+        const colorMap = colorsFor(asns);
+        expect(colorMap['AS100']).to.equal('rgb(225, 69, 51)');
+      });
+
+      it('provides colors for asns with accessor function', () => {
+        const asns = [{ 'asn':'AS100' }, { 'asn':'AS101' }];
+        const colorMap = colorsFor(asns, (d) => d.asn);
+        expect(colorMap['AS100']).to.equal('rgb(225, 69, 51)');
+      });
+    });
+  });
+});


### PR DESCRIPTION
Just to get the conversation started on the colors. this might be the complete wrong way to do it - but it might be a start.

I acquired 30 colors from http://tools.medialab.sciences-po.fr/iwanthue/

the `colorsFor` gets an array of values (with optional accessor) and returns a mapping from value to color. 

It does this for now by a simple modulo of the ASN number. if there are overlaps in the list, the idea is that duplicate colors can be lightened or darkened. So verizon will always be a red, for example. but might show up as a darker red some times. 

Anyways thats the idea.
Colors might be a bit garish - but that can be tweeked on the site and adjusted so they are the appropriate brightness and lightness for `mlab-vis-client`. 

Perhaps the returned object should be more `d3-color` like? instead of a plain object...
Perhaps it should be passed into components instead of imported directly?

![colors](https://cloud.githubusercontent.com/assets/9369/18331120/66c27ff2-7511-11e6-9803-3ace057eca5b.gif)
