### PR TITLE
Add in find methods for finding closest points in sorted data

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "babel-register": "^6.3.13",
     "babel-runtime": "^6.3.19",
     "better-npm-run": "^0.0.11",
+    "binary-search": "^1.3.2",
     "body-parser": "^1.14.1",
     "classnames": "^2.2.5",
     "clean-webpack-plugin": "^0.1.6",

--- a/src/components/LineChart/LineChart.jsx
+++ b/src/components/LineChart/LineChart.jsx
@@ -1,6 +1,6 @@
 import React, { PureComponent, PropTypes } from 'react';
 import d3 from 'd3';
-import { multiExtent, findClosestUnsorted, findEqualUnsorted } from '../../utils/array';
+import { multiExtent, findClosestSorted, findEqualSorted } from '../../utils/array';
 import { colorsFor } from '../../utils/color';
 
 import './LineChart.scss';
@@ -118,7 +118,7 @@ export default class LineChart extends PureComponent {
     if (series && series.length) {
       const [mouseX] = mouse;
       const checkSeries = series[0];
-      closest = findClosestUnsorted(checkSeries.results, mouseX, d => xScale(d[xKey]))[xKey];
+      closest = findClosestSorted(checkSeries.results, mouseX, d => xScale(d[xKey]))[xKey];
     }
 
     onHighlightDate(closest);
@@ -479,7 +479,7 @@ export default class LineChart extends PureComponent {
         let highlightValue;
         if (highlightDate) {
           // find equal (TODO should use binary search)
-          highlightValue = findEqualUnsorted(d.series.results, highlightDate.unix(), d => d[xKey].unix());
+          highlightValue = findEqualSorted(d.series.results, highlightDate.unix(), d => d[xKey].unix());
           if (highlightValue[yKey] != null) {
             highlightValue = yFormatter(highlightValue[yKey]);
           } else {

--- a/src/components/LineChartSmallMult/LineChartSmallMult.jsx
+++ b/src/components/LineChartSmallMult/LineChartSmallMult.jsx
@@ -1,7 +1,7 @@
 import React, { PureComponent, PropTypes } from 'react';
 import moment from 'moment';
 import d3 from 'd3';
-import { multiExtent } from '../../utils/array';
+import { multiExtent, findClosestSorted } from '../../utils/array';
 import { colorsFor } from '../../utils/color';
 
 
@@ -220,8 +220,6 @@ export default class LineChartSmallMult extends PureComponent {
       );
     }
 
-    const bisector = d3.bisector((d) => d[xKey]).left;
-
     return {
       colors,
       height,
@@ -239,7 +237,6 @@ export default class LineChartSmallMult extends PureComponent {
       xKey,
       yScales,
       metrics,
-      bisector,
       timeAggregation,
     };
   }
@@ -335,12 +332,13 @@ export default class LineChartSmallMult extends PureComponent {
    */
   renderChartLabels(series, chartId, seriesIndex, yKey, metricIndex) {
     const { hover, mouse } = this.state;
-    const { xScale, yScales, colors, bisector, showBaseline, timeAggregation } = this.visComponents;
+    const { xScale, yScales, colors, xKey, showBaseline } = this.visComponents;
 
-    const xValue = moment(xScale.invert(mouse[0])).startOf(timeAggregation);
+    // find the value closest to the mouse's x coordinate
+    const closest = findClosestSorted(series.results, mouse[0], d => xScale(d[xKey]));
+    const xValue = closest[xKey];
+    const yValue = closest[yKey];
 
-    const index = bisector(series.results, xValue, 0, series.results.length - 1);
-    const yValue = series.results[index][yKey];
     const color = ((showBaseline && seriesIndex === 0) ? '#bbb' : colors[series.meta.client_asn_number]);
     const darkColor = d3.color(color).darker();
 

--- a/src/utils/array.js
+++ b/src/utils/array.js
@@ -109,6 +109,8 @@ export function findClosestSorted(array, value, accessor = d => d) {
     }
   }
 
+  // this result is always to the right, so see if the one to the left is closer
+  // and use it if it is.
   let result = array[index];
   const before = array[index - 1];
   if (before != null && Math.abs(accessor(result) - value) > Math.abs(accessor(before) - value)) {

--- a/src/utils/array.js
+++ b/src/utils/array.js
@@ -1,4 +1,5 @@
 import d3 from 'd3';
+import binarySearch from 'binary-search';
 
 /**
  * Compute the extent across an array of arrays/objects
@@ -70,3 +71,71 @@ export function findClosestUnsorted(array, value, accessor = d => d) {
 export function findEqualUnsorted(array, value, accessor = d => d) {
   return array.find(d => accessor(d) === value);
 }
+
+
+/**
+ * Helper function to compute distance and find the closest item
+ * Since it assumes the data is sorted, it does a binary search O(log n)
+ *
+ * @param {Array} array the input array to search
+ * @param {Number} value the value to match against (typically pixels)
+ * @param {Function} accessor applied to each item in the array to get equivalent
+ *   value to compare against
+ * @return {Any} The item in the array that is closest to `value`
+ */
+export function findClosestSorted(array, value, accessor = d => d) {
+  // binary search uses the value directly in comparisons, so make sure not to
+  // run the accessor on it
+  let index = binarySearch(array, value, (a, b) => {
+    const aValue = a === value ? value : accessor(a);
+    const bValue = b === value ? value : accessor(b);
+    return aValue - bValue;
+  });
+
+
+  // index is positive = we found it exactly
+  if (index < 0) {
+    // should match first element
+    if (index === -1) {
+      index = 0;
+    } else {
+      // map back to the input location since the binary search uses -(low + 1) as the result
+      index = -index - 1;
+
+      // should match last element
+      if (index >= array.length) {
+        index = array.length - 1;
+      }
+    }
+  }
+
+  let result = array[index];
+  const before = array[index - 1];
+  if (before != null && Math.abs(accessor(result) - value) > Math.abs(accessor(before) - value)) {
+    result = before;
+  }
+
+  return result;
+}
+
+/**
+ * Helper function to find the item that matches this value.
+ * Since it assumes the data is sorted, it does a binary search O(log n)
+ *
+ * @param {Array} array the input array to search
+ * @param {Number} value the value to match against (typically pixels)
+ * @param {Function} accessor applied to each item in the array to get equivalent
+ *   value to compare against
+ * @return {Any} The item in the array that has this value or null if not found
+ */
+export function findEqualSorted(array, value, accessor = d => d) {
+  // binary search uses the value directly in comparisons, so make sure not to
+  // run the accessor on it
+  const index = binarySearch(array, value, (a, b) => {
+    const aValue = a === value ? value : accessor(a);
+    const bValue = b === value ? value : accessor(b);
+    return aValue - bValue;
+  });
+  return array[index];
+}
+

--- a/src/utils/tests/array-test.js
+++ b/src/utils/tests/array-test.js
@@ -1,5 +1,11 @@
 import { expect } from 'chai';
-import { multiExtent, findClosestUnsorted, findEqualUnsorted } from '../array';
+import {
+  multiExtent,
+  findClosestUnsorted,
+  findEqualUnsorted,
+  findClosestSorted,
+  findEqualSorted,
+} from '../array';
 
 describe('utils', () => {
   describe('array', () => {
@@ -36,9 +42,59 @@ describe('utils', () => {
       });
     });
 
-    describe('findClosestUnsorted', () => {
+    describe('findClosestSorted', () => {
       it('finds the closest value', () => {
         const values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+        expect(findClosestSorted(values, 0)).to.equal(1);
+        expect(findClosestSorted(values, 1)).to.equal(1);
+        expect(findClosestSorted(values, 3.49)).to.equal(3);
+        expect(findClosestSorted(values, 3.51)).to.equal(4);
+        expect(findClosestSorted(values, 11)).to.equal(10);
+        expect(findClosestSorted(values, 10)).to.equal(10);
+      });
+
+      it('works with accessor', () => {
+        const values = [{ a: 1 }, { a: 2 }, { a: 3 }, { a: 4 }, { a: 10 }];
+        const accessor = d => d.a;
+        expect(findClosestSorted(values, 0, accessor)).to.deep.equal({ a: 1 });
+        expect(findClosestSorted(values, 1, accessor)).to.deep.equal({ a: 1 });
+        expect(findClosestSorted(values, 3.49, accessor)).to.deep.equal({ a: 3 });
+        expect(findClosestSorted(values, 3.51, accessor)).to.deep.equal({ a: 4 });
+        expect(findClosestSorted(values, 11, accessor)).to.deep.equal({ a: 10 });
+        expect(findClosestSorted(values, 10, accessor)).to.deep.equal({ a: 10 });
+      });
+    });
+
+    describe('findEqualSorted', () => {
+      it('finds the value and returns it', () => {
+        const values = [1, 2, 3, 4, 10];
+        expect(findEqualSorted(values, 1)).to.equal(values[0]);
+        expect(findEqualSorted(values, 10)).to.equal(values[4]);
+        expect(findEqualSorted(values, 4)).to.equal(values[3]);
+        expect(findEqualSorted(values, 3)).to.equal(values[2]);
+      });
+
+      it('finds the value and returns it with accessor', () => {
+        const values = [{ a: 1 }, { a: 2 }, { a: 3 }, { a: 4 }, { a: 10 }];
+        const accessor = d => d.a;
+        expect(findEqualSorted(values, 1, accessor)).to.equal(values[0]);
+        expect(findEqualSorted(values, 10, accessor)).to.equal(values[4]);
+        expect(findEqualSorted(values, 4, accessor)).to.equal(values[3]);
+        expect(findEqualSorted(values, 3, accessor)).to.equal(values[2]);
+      });
+
+      it('returns undefined for not found', () => {
+        const values = [{ a: 1 }, { a: 2 }, { a: 3 }, { a: 4 }, { a: 10 }];
+        const accessor = d => d.a;
+        expect(findEqualSorted(values, 0, accessor)).to.be.undefined;
+        expect(findEqualSorted(values, 99, accessor)).to.be.undefined;
+      });
+    });
+
+    describe('findClosestUnsorted', () => {
+      it('finds the closest value', () => {
+        const values = [8, 9, 1, 2, 6, 3, 5, 4, 5, 10];
         expect(findClosestUnsorted(values, 0)).to.equal(1);
         expect(findClosestUnsorted(values, 1)).to.equal(1);
         expect(findClosestUnsorted(values, 3.49)).to.equal(3);
@@ -48,7 +104,7 @@ describe('utils', () => {
       });
 
       it('works with accessor', () => {
-        const values = [{ a: 1 }, { a: 2 }, { a: 3 }, { a: 4 }, { a: 10 }];
+        const values = [{ a: 4 }, { a: 2 }, { a: 1 }, { a: 10 }, { a: 3 }];
         const accessor = d => d.a;
         expect(findClosestUnsorted(values, 0, accessor)).to.deep.equal({ a: 1 });
         expect(findClosestUnsorted(values, 1, accessor)).to.deep.equal({ a: 1 });
@@ -61,15 +117,15 @@ describe('utils', () => {
 
     describe('findEqualUnsorted', () => {
       it('finds the value and returns it', () => {
-        const values = [{ a: 1 }, { a: 2 }, { a: 3 }, { a: 4 }, { a: 10 }];
+        const values = [{ a: 4 }, { a: 2 }, { a: 1 }, { a: 10 }, { a: 3 }];
         expect(findEqualUnsorted(values, values[0])).to.equal(values[0]);
         expect(findEqualUnsorted(values, values[4])).to.equal(values[4]);
         expect(findEqualUnsorted(values, values[3])).to.equal(values[3]);
-        expect(findEqualUnsorted(values, 3, d => d.a)).to.equal(values[2]);
+        expect(findEqualUnsorted(values, 3, d => d.a)).to.equal(values[4]);
       });
 
       it('returns undefined for not found', () => {
-        const values = [{ a: 1 }, { a: 2 }, { a: 3 }, { a: 4 }, { a: 10 }];
+        const values = [{ a: 4 }, { a: 2 }, { a: 1 }, { a: 10 }, { a: 3 }];
         expect(findEqualUnsorted(values, { a: 1 })).to.be.undefined;
         expect(findEqualUnsorted(values, { a: 99 })).to.be.undefined;
       });


### PR DESCRIPTION
Uses binary search to find the closest point since the data is sorted. This is better than using d3-bisector since it allows us to give 3 on 3.49 and 4 on 3.51 as opposed to always taking the floor or ceiling (as bisector does).