### PR TITLE
Add label to transformed API data and extract Legend into its own component

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -4,7 +4,9 @@ import {
   transformTimeSeries,
   transformHourly,
   transformSearchResults,
+  transformClientIspLabel,
   transformLocationInfo,
+  transformLocationLabel,
   transformFixedData,
   transformMapMeta,
 } from './transforms';
@@ -59,7 +61,7 @@ export function getLocationInfo(locationId) {
 export function getLocationTimeSeries(timeAggregation, locationId, options = {}) {
   const params = getDateRangeParams(timeAggregation, options);
   return get(`/locations/${locationId}/time/${timeAggregation}/metrics`, { params })
-    .then(transform(transformTimeSeries));
+    .then(transform(transformLocationLabel, transformTimeSeries));
 }
 
 /**
@@ -76,7 +78,7 @@ export function getLocationTimeSeries(timeAggregation, locationId, options = {})
 export function getLocationHourly(timeAggregation, locationId, options = {}) {
   const params = getDateRangeParams(timeAggregation, options);
   return get(`/locations/${locationId}/time/${timeAggregation}_hour/metrics`, { params })
-    .then(transform(transformHourly));
+    .then(transform(transformLocationLabel, transformHourly));
 }
 
 /**
@@ -93,7 +95,7 @@ export function getLocationClientIspTimeSeries(timeAggregation, locationId, clie
   const params = getDateRangeParams(timeAggregation, options);
 
   return get(`/locations/${locationId}/time/${timeAggregation}/clientisps/${clientIspId}/metrics`, { params })
-    .then(transform(transformTimeSeries));
+    .then(transform(transformClientIspLabel, transformTimeSeries));
 }
 
 
@@ -111,7 +113,7 @@ export function getLocationClientIspHourly(timeAggregation, locationId, clientIs
   const params = getDateRangeParams(timeAggregation, options);
 
   return get(`/locations/${locationId}/time/${timeAggregation}_hour/clientisps/${clientIspId}/metrics`, { params })
-    .then(transform(transformHourly));
+    .then(transform(transformClientIspLabel, transformHourly));
 }
 
 /**

--- a/src/api/transforms.js
+++ b/src/api/transforms.js
@@ -217,7 +217,7 @@ export function transformClientIspLabel(body) {
 export function transformLocationInfo(body) {
   // NOTE: modifying body directly means it modifies what is stored in the API cache
   if (body.meta) {
-    // add in label and ID
+    // add in label
     transformLocationLabel(body);
 
     const { meta } = body;

--- a/src/components/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.jsx
@@ -6,7 +6,7 @@ import './Breadcrumbs.scss';
 /**
  * Component for rendering navigation breadcrumbs for a location
  *
- * @prop {Object} info the location info object. contains name, parents ([{name, locationKey}, ...])
+ * @prop {Object} info the location info object. contains label, parents ([{label, id}, ...])
  */
 export default class Breadcrumbs extends PureComponent {
   static propTypes = {
@@ -15,23 +15,23 @@ export default class Breadcrumbs extends PureComponent {
   }
 
   static defaultProps = {
-    info: { name: 'Loading...' },
+    info: { label: 'Loading...' },
   }
 
   render() {
     const { info, query } = this.props;
-    const { name, parents = [] } = info;
+    const { label, parents = [] } = info;
 
     return (
       <div className="Breadcrumbs">
         <ul className="list-inline">
           {parents.map(parent => (
-            <li key={parent.locationKey}>
-              <Link to={`/location/${parent.locationKey}`} query={query}>{parent.name}</Link>
+            <li key={parent.id}>
+              <Link to={`/location/${parent.id}`} query={query}>{parent.label}</Link>
               <span className="breadcrumb-separator">/</span>
             </li>
           ))}
-          <li className="breadcrumb-current">{name}</li>
+          <li className="breadcrumb-current">{label}</li>
         </ul>
       </div>
     );

--- a/src/components/LineChart/LineChart.jsx
+++ b/src/components/LineChart/LineChart.jsx
@@ -367,9 +367,22 @@ export default class LineChart extends PureComponent {
   }
 
   renderLegend() {
-    const { legend } = this.visComponents;
+    const { highlightDate } = this.props;
+    const { series, legend, xKey, yKey } = this.visComponents;
+
     this.legendContainer.attr('transform', `translate(0 ${-legend.height})`);
-    legend.render(this.legendContainer);
+
+    let highlightValues;
+
+    if (highlightDate != null) {
+      // find the y value for the highlighted date
+      highlightValues = series.map(oneSeries => {
+        const value = findEqualSorted(oneSeries.results, highlightDate.unix(), d => d[xKey].unix());
+        return value == null ? value : value[yKey];
+      });
+    }
+
+    legend.render(this.legendContainer, highlightValues);
   }
 
   /**

--- a/src/components/LineChart/LineChart.jsx
+++ b/src/components/LineChart/LineChart.jsx
@@ -225,7 +225,7 @@ export default class LineChart extends PureComponent {
 
     // compute legend properties and make room for it at the top.
     const legend = new Legend({
-      data: series,
+      data: (series || []).concat(annotationSeries || []),
       colors,
       formatter: yFormatter,
       width: innerWidth,
@@ -368,7 +368,7 @@ export default class LineChart extends PureComponent {
 
   renderLegend() {
     const { highlightDate } = this.props;
-    const { series, legend, xKey, yKey } = this.visComponents;
+    const { series = [], annotationSeries = [], legend, xKey, yKey } = this.visComponents;
 
     this.legendContainer.attr('transform', `translate(0 ${-legend.height})`);
 
@@ -376,7 +376,7 @@ export default class LineChart extends PureComponent {
 
     if (highlightDate != null) {
       // find the y value for the highlighted date
-      highlightValues = series.map(oneSeries => {
+      highlightValues = series.concat(annotationSeries).map(oneSeries => {
         const value = findEqualSorted(oneSeries.results, highlightDate.unix(), d => d[xKey].unix());
         return value == null ? value : value[yKey];
       });

--- a/src/components/LineChart/LineChart.jsx
+++ b/src/components/LineChart/LineChart.jsx
@@ -368,6 +368,7 @@ export default class LineChart extends PureComponent {
 
   renderLegend() {
     const { legend } = this.visComponents;
+    this.legendContainer.attr('transform', `translate(0 ${-legend.height})`);
     legend.render(this.legendContainer);
   }
 

--- a/src/components/LineChart/LineChart.scss
+++ b/src/components/LineChart/LineChart.scss
@@ -1,8 +1,4 @@
 .line-chart {
-  .legend-entry {
-    font-size: 12px;
-  }
-
   .highlight-line path {
     stroke-width: 3px !important;
   }
@@ -10,10 +6,6 @@
   .series-overlay {
     fill: #fff;
     opacity: 0.7;
-  }
-
-  .legend-entry-value {
-    font-weight: 400;
   }
 
   .highlight-ref-line {

--- a/src/d3-components/Legend/Legend.js
+++ b/src/d3-components/Legend/Legend.js
@@ -43,8 +43,6 @@ export default class Legend {
    * @return {void}
    */
   render(root) {
-    root.attr('transform', `translate(0 ${-this.height})`);
-
     const binding = root.selectAll('.legend-entry').data(this.data, d => d.meta.id);
     binding.exit().remove();
 

--- a/src/d3-components/Legend/Legend.js
+++ b/src/d3-components/Legend/Legend.js
@@ -47,10 +47,11 @@ export default class Legend {
     const binding = root.selectAll('.legend-entry').data(this.data, d => d.meta.id);
     binding.exit().remove();
 
-    const that = this;
     const { entry: entryConfig, colorBox: colorBoxConfig } = this.config;
     const colors = this.colors;
+    const onHoverLegendEntry = this.onHoverLegendEntry;
 
+    // render entering entries (one per item in data)
     const entering = binding.enter().append('g')
       .attr('class', 'legend-entry')
       .each(function legendEnter(d) {
@@ -58,9 +59,13 @@ export default class Legend {
 
         const entryId = String(Math.random()).replace(/\./, '');
         const clipId = `legend-clip-${entryId}`;
+
+        // use the provided color or default to gray
+        const color = colors[d.meta.id] || '#aaa';
+
         entry.attr('clip-path', `url(#${clipId})`);
 
-        // add in the clipping rects
+        // add in the clipping rects to prevent text from extending beyond the width
         entry.append('defs')
           .append('clipPath')
             .attr('id', clipId)
@@ -68,20 +73,23 @@ export default class Legend {
             .attr('width', entryConfig.width)
             .attr('height', entryConfig.height);
 
-
+        // draw the color box
         entry.append('rect')
           .attr('class', 'legend-color-box')
           .attr('y', 3)
           .attr('width', colorBoxConfig.width)
           .attr('height', colorBoxConfig.width)
-          .style('fill', colors[d.meta.id] || '#aaa');
+          .style('fill', color);
 
+        // draw the label for the entry
         entry.append('text')
           .attr('class', 'legend-entry-label')
           .attr('x', colorBoxConfig.width + colorBoxConfig.margin)
           .attr('dy', 12)
           .text(d.meta.label);
 
+        // prepare the area where values are shown
+        // this is the white bg rect to overlap the label text if necessary
         entry.append('rect')
           .attr('class', 'legend-entry-value-bg')
           .attr('x', entryConfig.width)
@@ -89,27 +97,30 @@ export default class Legend {
           .attr('height', entryConfig.height)
           .style('fill', '#fff');
 
+        // the value text element when values are provided
         entry.append('text')
           .attr('class', 'legend-entry-value')
           .attr('dy', 12)
           .attr('x', entryConfig.width)
           .attr('text-anchor', 'end')
-          .style('fill', colors[d.meta.id] || '#aaa');
+          .style('fill', color);
 
-        // mouse listener rect
+        // mouse listener rect over the entry
         entry.append('rect')
           .attr('width', entryConfig.width)
           .attr('height', entryConfig.height)
           .style('fill', '#f00')
           .style('stroke', 'none')
           .style('opacity', 0)
-          .on('mouseenter', () => that.onHoverLegendEntry(d))
-          .on('mouseleave', () => that.onHoverLegendEntry(null));
+          .on('mouseenter', () => onHoverLegendEntry(d))
+          .on('mouseleave', () => onHoverLegendEntry(null));
       });
 
-    // UPDATE + ENTER -- mostly for hover behavior
     const formatter = this.formatter;
+
+    // UPDATE + ENTER -- mostly for hover behavior to show values
     binding.merge(entering)
+      // ensure the entry is in the correct position
       .attr('transform', (d, i) => {
         const rowNum = Math.floor(i / this.numEntriesPerRow);
         const numInRow = i % this.numEntriesPerRow;
@@ -118,25 +129,31 @@ export default class Legend {
         const y = rowNum * (entryConfig.height + entryConfig.margin.bottom);
         return `translate(${x} ${y})`;
       })
+      // show the current value or hide it if no values provided
       .each(function legendUpdate(d, i) {
         const entry = d3.select(this);
 
+        // if value is nully render it as -- otherwise use the formatter
         let highlightValue;
         if (values) {
           highlightValue = values[i] == null ? '--' : formatter(values[i]);
         }
 
+        // if a value was provided, render it
         if (highlightValue !== undefined) {
           const valueText = entry.select('.legend-entry-value')
             .style('display', '')
             .text(highlightValue);
 
+          // make sure the bg rect is wide enough to fit the value on top
           const valueTextBBox = valueText.node().getBBox();
           const valueTextMargin = 4;
           entry.select('.legend-entry-value-bg')
             .style('display', '')
             .attr('x', Math.floor(valueTextBBox.x) - valueTextMargin)
             .attr('width', (2 * valueTextMargin) + Math.ceil(valueTextBBox.width));
+
+        // no highlight value, so hide it
         } else {
           entry.select('.legend-entry-value').style('display', 'none');
           entry.select('.legend-entry-value-bg').style('display', 'none');

--- a/src/d3-components/Legend/Legend.js
+++ b/src/d3-components/Legend/Legend.js
@@ -1,0 +1,153 @@
+import d3 from 'd3';
+import { findEqualSorted } from '../../utils/array';
+
+/**
+ * D3 Component for rendering a legend
+ * Typically initialized in makeVisComponents() and then rendered with a passed in
+ * root container node.
+ */
+export default class Legend {
+  constructor({ data, colors, formatter, width, onHoverLegendEntry }) {
+    this.data = data;
+    this.colors = colors;
+    this.formatter = formatter;
+    this.width = width;
+    this.onHoverLegendEntry = onHoverLegendEntry;
+
+    const entryMarginRight = 14;
+    const minEntryWidth = 180;
+    const maxEntriesPerRow = 3;
+
+    this.config = {
+      entry: {
+        height: 14,
+        width: Math.max(Math.floor(this.width / maxEntriesPerRow) - entryMarginRight, minEntryWidth),
+        margin: { bottom: 4, right: entryMarginRight },
+      },
+      colorBox: {
+        width: 8,
+        margin: 2,
+      },
+    };
+
+    this.numEntriesPerRow = Math.floor(this.width / this.config.entry.width);
+    this.numRows = Math.ceil(data.length / this.numEntriesPerRow);
+    const legendPaddingBottom = 4;
+    this.height = (this.numRows * (this.config.entry.height + this.config.entry.margin.bottom)) + legendPaddingBottom;
+  }
+
+  /**
+   * Renders the legend to the `root` container
+   *
+   * @param {Object} root A d3 selection of a container to render the legend in
+   * @return {void}
+   */
+  render(root) {
+    root.attr('transform', `translate(0 ${-this.height})`);
+
+    const binding = root.selectAll('.legend-entry').data(this.data, d => d.meta.id);
+    binding.exit().remove();
+
+    const that = this;
+    const { entry: entryConfig, colorBox: colorBoxConfig } = this.config;
+    const colors = this.colors;
+
+    const entering = binding.enter().append('g')
+      .attr('class', 'legend-entry')
+      .each(function legendEnter(d) {
+        const entry = d3.select(this);
+
+        const entryId = String(Math.random()).replace(/\./, '');
+        const clipId = `legend-clip-${entryId}`;
+        entry.attr('clip-path', `url(#${clipId})`);
+
+        // add in the clipping rects
+        entry.append('defs')
+          .append('clipPath')
+            .attr('id', clipId)
+          .append('rect')
+            .attr('width', entryConfig.width)
+            .attr('height', entryConfig.height);
+
+
+        entry.append('rect')
+          .attr('class', 'legend-color-box')
+          .attr('y', 3)
+          .attr('width', colorBoxConfig.width)
+          .attr('height', colorBoxConfig.width)
+          .style('fill', colors[d.meta.id] || '#aaa');
+
+        entry.append('text')
+          .attr('class', 'legend-entry-label')
+          .attr('x', colorBoxConfig.width + colorBoxConfig.margin)
+          .attr('dy', 12)
+          .text(d.meta.label);
+
+        entry.append('rect')
+          .attr('class', 'legend-entry-value-bg')
+          .attr('x', entryConfig.width)
+          .attr('width', 0)
+          .attr('height', entryConfig.height)
+          .style('fill', '#fff');
+
+        entry.append('text')
+          .attr('class', 'legend-entry-value')
+          .attr('dy', 12)
+          .attr('x', entryConfig.width)
+          .attr('text-anchor', 'end')
+          .style('fill', colors[d.meta.id] || '#aaa');
+
+        // mouse listener rect
+        entry.append('rect')
+          .attr('width', entryConfig.width)
+          .attr('height', entryConfig.height)
+          .style('fill', '#f00')
+          .style('stroke', 'none')
+          .style('opacity', 0)
+          .on('mouseenter', () => that.onHoverLegendEntry(d))
+          .on('mouseleave', () => that.onHoverLegendEntry(null));
+      });
+
+    // UPDATE + ENTER -- mostly for hover behavior
+    binding.merge(entering)
+      .attr('transform', (d, i) => {
+        const rowNum = Math.floor(i / this.numEntriesPerRow);
+        const numInRow = i % this.numEntriesPerRow;
+
+        const x = numInRow * (entryConfig.width + entryConfig.margin.right);
+        const y = rowNum * (entryConfig.height + entryConfig.margin.bottom);
+        return `translate(${x} ${y})`;
+      })
+      // .each(function legendUpdate(d) {
+      //   const entry = d3.select(this);
+
+      //   // TODO: get highlight values
+      //   let highlightValue;
+      //   if (highlightDate) {
+      //     // find equal (TODO should use binary search)
+      //     highlightValue = findEqualSorted(d.series.results, highlightDate.unix(), d => d[xKey].unix());
+      //     if (highlightValue[yKey] != null) {
+      //       highlightValue = yFormatter(highlightValue[yKey]);
+      //     } else {
+      //       highlightValue = '--';
+      //     }
+      //   }
+
+      //   if (highlightValue != null) {
+      //     const valueText = entry.select('.legend-entry-value')
+      //       .style('display', '')
+      //       .text(highlightValue);
+
+      //     const valueTextBBox = valueText.node().getBBox();
+      //     const valueTextMargin = 4;
+      //     entry.select('.legend-entry-value-bg')
+      //       .style('display', '')
+      //       .attr('x', Math.floor(valueTextBBox.x) - valueTextMargin)
+      //       .attr('width', (2 * valueTextMargin) + Math.ceil(valueTextBBox.width));
+      //   } else {
+      //     entry.select('.legend-entry-value').style('display', 'none');
+      //     entry.select('.legend-entry-value-bg').style('display', 'none');
+      //   }
+      // });
+  }
+}

--- a/src/d3-components/Legend/Legend.js
+++ b/src/d3-components/Legend/Legend.js
@@ -1,5 +1,6 @@
 import d3 from 'd3';
 
+import './Legend.scss';
 /**
  * D3 Component for rendering a legend
  * Typically initialized in makeVisComponents() and then rendered with a passed in
@@ -38,12 +39,17 @@ export default class Legend {
   /**
    * Renders the legend to the `root` container
    *
-   * @param {Object} root A d3 selection of a container to render the legend in
+   * @param {Object} container A d3 selection of a container to render the legend in
    * @param {Array} values Array of values corresponding to the data array. If provided,
    *   these values show up in the legend (typically used for mouse behavior)
    * @return {void}
    */
-  render(root, values) {
+  render(container, values) {
+    let root = container.select('.Legend');
+    if (root.empty()) {
+      root = container.append('g').attr('class', 'Legend');
+    }
+
     const binding = root.selectAll('.legend-entry').data(this.data, d => d.meta.id);
     binding.exit().remove();
 

--- a/src/d3-components/Legend/Legend.scss
+++ b/src/d3-components/Legend/Legend.scss
@@ -1,0 +1,8 @@
+.Legend {
+  .legend-entry {
+    font-size: 12px;
+  }
+  .legend-entry-value {
+    font-weight: 400;
+  }
+}

--- a/src/d3-components/index.js
+++ b/src/d3-components/index.js
@@ -1,0 +1,8 @@
+/**
+ *  Point of contact for d3 component modules
+ *
+ *  ie: import { Legend, SomeOther } from 'd3-components';
+ *
+ */
+
+export Legend from './Legend/Legend';


### PR DESCRIPTION
Adding labels to the transformed API data was a necessary first step before extracting the legend into its own component so it could just read IDs and Labels from the data. The API server was updated to provide IDs during the creation of this PR. 

Legend has been extracted into its own component in the `d3-components` subdirectory and is currently only used by LineChart. 