### PR TITLE
Update small mults style

### DIFF
--- a/src/components/LineChartSmallMult/LineChartSmallMult.jsx
+++ b/src/components/LineChartSmallMult/LineChartSmallMult.jsx
@@ -332,7 +332,7 @@ export default class LineChartSmallMult extends PureComponent {
    */
   renderChartLabels(series, chartId, seriesIndex, yKey, metricIndex) {
     const { hover, mouse } = this.state;
-    const { xScale, yScales, colors, xKey, showBaseline } = this.visComponents;
+    const { xScale, yScales, colors, xKey, showBaseline, metrics } = this.visComponents;
 
     // find the value closest to the mouse's x coordinate
     const closest = findClosestSorted(series.results, mouse[0], d => xScale(d[xKey]));
@@ -341,6 +341,7 @@ export default class LineChartSmallMult extends PureComponent {
 
     const color = ((showBaseline && seriesIndex === 0) ? '#bbb' : colors[series.meta.client_asn_number]);
     const darkColor = d3.color(color).darker();
+    const yFormatter = metrics[metricIndex].formatter || (d => d);
 
     if (hover && yValue) {
       return (
@@ -355,7 +356,7 @@ export default class LineChartSmallMult extends PureComponent {
             textAnchor="start"
             className="small-mult-label small-mult-hover-label"
           >
-            {yValue}
+            {yFormatter(yValue)}
           </text>
         </g>
       );

--- a/src/components/LineChartSmallMult/LineChartSmallMult.jsx
+++ b/src/components/LineChartSmallMult/LineChartSmallMult.jsx
@@ -136,7 +136,7 @@ export default class LineChartSmallMult extends PureComponent {
             metrics,
             chartHeight,
             timeAggregation,
-            innerMarginLeft = 50,
+            innerMarginLeft = 3, // leave enough room for circle radius
             innerMarginRight = 20,
             innerMarginTop = 40,
             chartPadding = 30,
@@ -344,16 +344,12 @@ export default class LineChartSmallMult extends PureComponent {
 
     if (hover && yValue) {
       return (
-        <g>
-          <circle
-            cx={xScale(xValue)}
-            cy={yScales[metricIndex](yValue)}
-            r={3}
-            fill={darkColor}
-          />
+        <g transform={`translate(${xScale(xValue)} ${yScales[metricIndex](yValue)})`}>
+          <rect x={0} y={-8} width={50} height={14} fill={'#fff'} />
+          <circle cx={0} cy={0} r={3} fill={darkColor} />
           <text
-            x={xScale(xValue)}
-            y={yScales[metricIndex](yValue)}
+            x={0}
+            y={0}
             dy={3}
             dx={6}
             textAnchor="start"
@@ -429,7 +425,7 @@ export default class LineChartSmallMult extends PureComponent {
       return (
         <text
           key={metric.dataKey}
-          className="small-mult-label small-mult-title"
+          className="small-mult-title"
           x={xPos}
           y={chartPadding}
           textAnchor="start"

--- a/src/components/LineChartSmallMult/LineChartSmallMult.scss
+++ b/src/components/LineChartSmallMult/LineChartSmallMult.scss
@@ -6,7 +6,7 @@
   }
 
   .small-mult-title {
-    font-weight: bold;
+    font-weight: 500;
   }
 
   .small-mult-name {
@@ -14,8 +14,8 @@
   }
 
   .small-mult-hover-label {
-    fill: #000;
-    font-weight: bold;
+    fill: #333;
+    font-weight: 500;
     font-size: 0.8em;
   }
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -32,6 +32,6 @@ export const metrics = [
     value: 'retransmission',
     label: 'Retransmission Rate',
     dataKey: 'retransmit_avg',
-    formatter: d3.format('.1f'),
+    formatter: d3.format('.1p'),
   },
 ];


### PR DESCRIPTION
Update the styling of the small mults by changing font weights, colors, adding a white bg behind tooltip text and using a formatter on the tooltip text.

![small_mults_style](https://cloud.githubusercontent.com/assets/793847/18522572/9280fd90-7a7e-11e6-9741-ed0e4a8fce6e.gif)
