### PR TITLE
Show count values on mouse interaction

### DIFF
--- a/src/components/CountChart/CountChart.jsx
+++ b/src/components/CountChart/CountChart.jsx
@@ -11,6 +11,7 @@ import './CountChart.scss';
  * @prop {String} highlightColor Color used to render the highlighted bars if provided
  * @prop {Object} highlightCount The date being highlighted in the chart
  * @prop {Array} highlightData Used to highlight a subset of the count data (typically a series object with { meta, results })
+ * @prop {Function} onHighlightCount Callback when the mouse hovers over a bar. Passes in the x value.
  */
 export default class CountChart extends PureComponent {
 
@@ -23,6 +24,7 @@ export default class CountChart extends PureComponent {
     innerMarginLeft: PropTypes.number,
     innerMarginRight: PropTypes.number,
     numBins: PropTypes.number,
+    onHighlightCount: PropTypes.func,
     width: PropTypes.number,
     xExtent: PropTypes.array,
     xKey: React.PropTypes.string,
@@ -65,6 +67,16 @@ export default class CountChart extends PureComponent {
    */
   componentDidUpdate() {
     this.update();
+  }
+
+  /**
+   * callback for when mouse hovers over a count bar
+   */
+  onHoverCountBar(xValue) {
+    const { onHighlightCount } = this.props;
+    if (onHighlightCount) {
+      onHighlightCount(xValue);
+    }
   }
 
   /**
@@ -197,7 +209,7 @@ export default class CountChart extends PureComponent {
   renderMainBars() {
     const { data } = this.visComponents;
 
-    this.renderBars(this.bars, data, '#ccc');
+    this.renderBars(this.bars, data, '#ccc', true);
   }
 
   /**
@@ -212,7 +224,7 @@ export default class CountChart extends PureComponent {
   /**
    * Helper function to render the rects
    */
-  renderBars(root, data = [], color = '#ccc') {
+  renderBars(root, data = [], color = '#ccc', addHandlers) {
     const {
       xKey,
       xScale,
@@ -237,6 +249,12 @@ export default class CountChart extends PureComponent {
         .style('shape-rendering', 'crispEdges')
         .style('fill', d => (d.belowThreshold ? '#fff' : lighterColor))
         .style('stroke', d => (d.belowThreshold ? '#ddd' : color));
+
+    if (addHandlers) {
+      entering
+        .on('mouseenter', d => this.onHoverCountBar(d[xKey]))
+        .on('mouseleave', () => this.onHoverCountBar(null));
+    }
 
     // ENTER + UPDATE
     binding.merge(entering)

--- a/src/components/CountChart/CountChart.scss
+++ b/src/components/CountChart/CountChart.scss
@@ -1,2 +1,10 @@
 .CountChart {
+  .highlighted {
+    fill: blue !important;
+  }
+
+  .highlight-count-bar {
+    font-size: 10px;
+    font-weight: 500;
+  }
 }

--- a/src/components/CountChart/CountChart.scss
+++ b/src/components/CountChart/CountChart.scss
@@ -4,6 +4,7 @@
   }
 
   .highlight-count-bar {
+    pointer-events: none;
     font-size: 10px;
     font-weight: 500;
   }

--- a/src/components/LineChart/LineChart.jsx
+++ b/src/components/LineChart/LineChart.jsx
@@ -44,10 +44,10 @@ export default class LineChart extends PureComponent {
     width: React.PropTypes.number,
     xExtent: PropTypes.array,
     xKey: React.PropTypes.string,
-    yExtent: PropTypes.array,
-    yFormatter: PropTypes.func,
     yAxisLabel: React.PropTypes.string,
     yAxisUnit: React.PropTypes.string,
+    yExtent: PropTypes.array,
+    yFormatter: PropTypes.func,
     yKey: React.PropTypes.string,
   }
 

--- a/src/components/LineChart/LineChartWithCounts.jsx
+++ b/src/components/LineChart/LineChartWithCounts.jsx
@@ -44,10 +44,10 @@ export default class LineChartWithCounts extends PureComponent {
     width: React.PropTypes.number,
     xExtent: PropTypes.array,
     xKey: React.PropTypes.string,
-    yExtent: PropTypes.array,
-    yFormatter: PropTypes.func,
     yAxisLabel: React.PropTypes.string,
     yAxisUnit: React.PropTypes.string,
+    yExtent: PropTypes.array,
+    yFormatter: PropTypes.func,
     yKey: React.PropTypes.string,
   }
 
@@ -76,7 +76,7 @@ export default class LineChartWithCounts extends PureComponent {
    * @return {Array} the prepared data
    */
   prepareData(props) {
-    const { series, highlightLine } = props;
+    const { series } = props;
 
     if (!series) {
       return {};
@@ -159,7 +159,7 @@ export default class LineChartWithCounts extends PureComponent {
    * @return {React.Component} The rendered container
    */
   render() {
-    const { id, width, xKey, annotationSeries, series, highlightLine } = this.props;
+    const { id, width, xKey, annotationSeries, series, highlightLine, highlightDate } = this.props;
     const { counts, innerMargin, xScale, numBins, colors } = this.visComponents;
 
     const lineChartHeight = 350;
@@ -195,6 +195,7 @@ export default class LineChartWithCounts extends PureComponent {
             <CountChart
               data={counts} /* TODO figure out multi-series counts */
               highlightData={highlightCountData}
+              highlightCount={highlightDate}
               highlightColor={highlightColor}
               height={countHeight}
               innerMarginLeft={innerMargin.left}

--- a/src/components/LineChart/LineChartWithCounts.jsx
+++ b/src/components/LineChart/LineChartWithCounts.jsx
@@ -159,7 +159,7 @@ export default class LineChartWithCounts extends PureComponent {
    * @return {React.Component} The rendered container
    */
   render() {
-    const { id, width, xKey, annotationSeries, series, highlightLine, highlightDate } = this.props;
+    const { id, width, xKey, annotationSeries, series, highlightLine, highlightDate, onHighlightDate } = this.props;
     const { counts, innerMargin, xScale, numBins, colors } = this.visComponents;
 
     const lineChartHeight = 350;
@@ -200,6 +200,7 @@ export default class LineChartWithCounts extends PureComponent {
               height={countHeight}
               innerMarginLeft={innerMargin.left}
               innerMarginRight={innerMargin.right}
+              onHighlightCount={onHighlightDate}
               numBins={numBins}
               width={width}
               xKey={xKey}


### PR DESCRIPTION
Adds in count values visible when mousing over the main chart or the count chart itself.

![a_count_interaction](https://cloud.githubusercontent.com/assets/793847/18529276/6b021e68-7a9a-11e6-96c7-c757fef6b746.gif)
