### PR TITLE
Improve hour chart layout and colors

### DIFF
--- a/src/components/HourChart/HourChart.jsx
+++ b/src/components/HourChart/HourChart.jsx
@@ -6,6 +6,7 @@ import './HourChart.scss';
 /**
  * Chart for showing data by hour
  *
+ * @prop {String} color The color to render the chart in
  * @prop {Array} data The array of data points indexed by hour. Should be
  *   an array of length 24 of form [{ hour:Number(0..23), points: [{ yKey:Number }, ...]}, ...]
  * @prop {Boolean} forceZeroMin=true Whether the min y value should always be 0.
@@ -18,6 +19,7 @@ import './HourChart.scss';
  */
 export default class HourChart extends PureComponent {
   static propTypes = {
+    color: PropTypes.string,
     data: PropTypes.array,
     dataByDate: PropTypes.object,
     dataByHour: PropTypes.array,
@@ -38,6 +40,7 @@ export default class HourChart extends PureComponent {
 
   static defaultProps = {
     data: [],
+    color: '#aaa',
     forceZeroMin: true,
     threshold: 30,
     yKey: 'y',
@@ -123,7 +126,7 @@ export default class HourChart extends PureComponent {
   makeVisComponents(props) {
     const { dataByHour, dataByDate, data, forceZeroMin, height,
       innerMarginLeft = 50, innerMarginRight = 20, overallData,
-      width, yExtent, yKey } = props;
+      width, yExtent, yKey, color } = props;
     let { xScale } = props;
 
     const innerMargin = {
@@ -164,12 +167,17 @@ export default class HourChart extends PureComponent {
       .x((d) => xScale(d.hour) + (binWidth / 2))
       .y((d) => yScale(d[yKey]));
 
+    // for highlighted dates
+    const highlightColor = 'rgb(245, 46, 113)';
+
     return {
       binWidth,
+      color,
       dataByHour,
       dataByDate,
       data,
       height,
+      highlightColor,
       innerHeight,
       innerMargin,
       innerWidth,
@@ -239,7 +247,7 @@ export default class HourChart extends PureComponent {
    * Render some circles in the chart
    */
   renderCircles() {
-    const { dataByHour, xScale, yScale, yKey, binWidth } = this.visComponents;
+    const { dataByHour, xScale, yScale, yKey, binWidth, color } = this.visComponents;
 
     const binding = this.circles
       .selectAll('g')
@@ -264,7 +272,7 @@ export default class HourChart extends PureComponent {
         // ENTER
         const entering = hourBinding.enter()
           .append('circle')
-          .style('fill', 'rgb(34, 121, 181)');
+          .style('fill', color);
 
         // ENTER + UPDATE
         hourBinding
@@ -284,15 +292,15 @@ export default class HourChart extends PureComponent {
   }
 
   renderOverallLine() {
-    const { overallData } = this.visComponents;
-    this.renderLine(overallData, this.gOverallLine, { stroke: 'rgb(204, 204, 245)' });
+    const { overallData, color } = this.visComponents;
+    this.renderLine(overallData, this.gOverallLine, { stroke: color });
   }
 
   /**
    * Renders the highlighted points
    */
   renderHighlight() {
-    const { binWidth, dataByDate, xScale, yKey, yScale } = this.visComponents;
+    const { binWidth, dataByDate, xScale, yKey, yScale, highlightColor } = this.visComponents;
     const { highlightPoint } = this.props;
 
     // if no highlight, remove all children
@@ -308,7 +316,6 @@ export default class HourChart extends PureComponent {
     const g = this.gHighlight.select('.highlight-line');
 
     // render a line
-    const highlightColor = 'rgb(245, 46, 113)';
     this.renderLine(dateData, g, { stroke: highlightColor });
 
     // also render some brighter circles

--- a/src/components/HourChart/HourChartWithCounts.jsx
+++ b/src/components/HourChart/HourChartWithCounts.jsx
@@ -7,6 +7,7 @@ import { sum, average } from '../../utils/math';
 /**
  * Chart for showing data by hour and with test counts
  *
+ * @prop {String} color The color to render the chart in
  * @prop {Array} data The array of data points indexed by hour. Should be
  *   an array of length 24 of form [{ hour:Number(0..23), points: [{ yKey:Number }, ...]}, ...]
  * @prop {Boolean} forceZeroMin=true Whether the min y value should always be 0.
@@ -18,6 +19,7 @@ import { sum, average } from '../../utils/math';
  */
 export default class HourChartWithCounts extends PureComponent {
   static propTypes = {
+    color: PropTypes.string,
     data: PropTypes.array,
     forceZeroMin: PropTypes.bool,
     highlightPoint: PropTypes.object,
@@ -141,7 +143,7 @@ export default class HourChartWithCounts extends PureComponent {
    * @return {React.Component} The rendered container
    */
   render() {
-    const { id, width } = this.props;
+    const { id, width, color } = this.props;
     const { dataByHour, dataByDate, filteredData, innerMargin, overallData,
       xScale, numBins } = this.visComponents;
 
@@ -161,6 +163,7 @@ export default class HourChartWithCounts extends PureComponent {
           <g>
             <HourChart
               {...this.props}
+              color={color}
               data={filteredData}
               dataByHour={dataByHour}
               dataByDate={dataByDate}

--- a/src/containers/LocationPage/LocationPage.jsx
+++ b/src/containers/LocationPage/LocationPage.jsx
@@ -8,6 +8,7 @@ import * as LocationPageSelectors from '../../redux/locationPage/selectors';
 import * as LocationPageActions from '../../redux/locationPage/actions';
 import * as LocationsActions from '../../redux/locations/actions';
 
+import { colorsFor } from '../../utils/color';
 import { metrics } from '../../constants';
 
 import {
@@ -462,6 +463,9 @@ class LocationPage extends PureComponent {
 
   renderProvidersByHour() {
     const { locationHourly, clientIspHourly } = this.props;
+
+    const colors = colorsFor(clientIspHourly, (d) => d.meta.id);
+
     return (
       <div className="subsection">
         <header>
@@ -469,13 +473,13 @@ class LocationPage extends PureComponent {
         </header>
         <Row>
           {this.renderHourChart(locationHourly)}
-          {clientIspHourly.map(hourly => this.renderHourChart(hourly))}
+          {clientIspHourly.map(hourly => this.renderHourChart(hourly, colors[hourly.meta.id]))}
         </Row>
       </div>
     );
   }
 
-  renderHourChart(hourlyData) {
+  renderHourChart(hourlyData, color) {
     const { hourlyStatus, highlightHourly, locationId, viewMetric } = this.props;
     const extentKey = this.extentKey(viewMetric);
 
@@ -491,6 +495,7 @@ class LocationPage extends PureComponent {
         <div className="clearfix">
           <StatusWrapper status={hourlyStatus}>
             <HourChartWithCounts
+              color={color}
               data={hourlyData.results}
               highlightPoint={highlightHourly}
               id={chartId}

--- a/src/containers/LocationPage/LocationPage.jsx
+++ b/src/containers/LocationPage/LocationPage.jsx
@@ -336,6 +336,7 @@ class LocationPage extends PureComponent {
 
     return (
       <div className="client-isp-selector">
+        <h5>Client ISPs</h5>
         <IspSelect
           isps={topClientIsps}
           selected={selectedClientIspInfo}

--- a/src/containers/LocationPage/LocationPage.jsx
+++ b/src/containers/LocationPage/LocationPage.jsx
@@ -461,72 +461,53 @@ class LocationPage extends PureComponent {
   }
 
   renderProvidersByHour() {
-    const { locationHourly, hourlyStatus, highlightHourly, locationId, viewMetric } = this.props;
-    const extentKey = this.extentKey(viewMetric);
-    const chartId = 'providers-hourly';
-    const chartData = locationHourly && locationHourly.results;
-
+    const { locationHourly, clientIspHourly } = this.props;
     return (
       <div className="subsection">
         <header>
           <h3>By Hour, Median download speeds</h3>
         </header>
-        <div className="clearfix">
-          <StatusWrapper status={hourlyStatus}>
-            <HourChartWithCounts
-              data={locationHourly && locationHourly.results}
-              highlightPoint={highlightHourly}
-              id={chartId}
-              onHighlightPoint={this.onHighlightHourly}
-              threshold={30}
-              width={800}
-              yExtent={locationHourly && locationHourly.extents[extentKey]}
-              yKey={viewMetric.dataKey}
-            />
-            <ChartExportControls
-              chartId={chartId}
-              data={chartData}
-              filename={`${locationId}_${viewMetric.value}_${chartId}`}
-            />
-          </StatusWrapper>
-        </div>
-        {this.renderClientIspsByHour()}
+        <Row>
+          {this.renderHourChart(locationHourly)}
+          {clientIspHourly.map(hourly => this.renderHourChart(hourly))}
+        </Row>
       </div>
     );
   }
 
-  renderClientIspsByHour() {
-    const { clientIspHourly, hourlyStatus, highlightHourly, locationId, viewMetric } = this.props;
+  renderHourChart(hourlyData) {
+    const { hourlyStatus, highlightHourly, locationId, viewMetric } = this.props;
     const extentKey = this.extentKey(viewMetric);
 
+    if (!hourlyData || !hourlyData.meta) {
+      return null;
+    }
+
+    const id = hourlyData.meta.id;
+    const chartId = `providers-hourly-${id}`;
     return (
-      <Row>
-        {clientIspHourly.map(hourly => {
-          const clientIspId = hourly.meta.client_asn_number;
-          const chartId = `providers-hourly-${clientIspId}`;
-          return (
-            <Col md={6} key={clientIspId}>
-              <StatusWrapper status={hourlyStatus}>
-                <HourChartWithCounts
-                  data={hourly.results}
-                  highlightPoint={highlightHourly}
-                  id={chartId}
-                  onHighlightPoint={this.onHighlightHourly}
-                  threshold={30}
-                  width={400}
-                  yExtent={hourly.extents[extentKey]}
-                  yKey={viewMetric.dataKey}
-                />
-                <ChartExportControls
-                  chartId={chartId}
-                  data={hourly.results}
-                  filename={`${locationId}_${clientIspId}_${viewMetric.value}_${chartId}`}
-                />
-              </StatusWrapper>
-            </Col>
-          );
-        })}
-      </Row>
+      <Col md={6} key={id}>
+        <h4>{hourlyData.meta.label}</h4>
+        <div className="clearfix">
+          <StatusWrapper status={hourlyStatus}>
+            <HourChartWithCounts
+              data={hourlyData.results}
+              highlightPoint={highlightHourly}
+              id={chartId}
+              onHighlightPoint={this.onHighlightHourly}
+              threshold={30}
+              width={400}
+              yExtent={hourlyData.extents[extentKey]}
+              yKey={viewMetric.dataKey}
+            />
+            <ChartExportControls
+              chartId={chartId}
+              data={hourlyData.results}
+              filename={`${locationId}${id === locationId ? '' : `_${id}`}_${viewMetric.value}_${chartId}`}
+            />
+          </StatusWrapper>
+        </div>
+      </Col>
     );
   }
 


### PR DESCRIPTION
- Refactors the hour chart rendering code in LocationPage
- Renders the hour charts all with the same width
- Adds headers to the hour charts
- Uses the colors seen throughout the page in the charts

![pasted_image_at_2016_09_14_05_50_pm](https://cloud.githubusercontent.com/assets/793847/18531561/e6f8816a-7aa4-11e6-88c3-66f24e1e0f12.png)
)
