### PR TITLE
Switch to standard names for dimensions

### DIFF
--- a/src/components/CountChart/CountChart.jsx
+++ b/src/components/CountChart/CountChart.jsx
@@ -11,8 +11,8 @@ import './CountChart.scss';
 function visProps(props) {
   const {
     height,
-    innerMarginLeft = 50,
-    innerMarginRight = 20,
+    paddingLeft = 50,
+    paddingRight = 20,
     width,
     xKey,
     xExtent,
@@ -24,19 +24,19 @@ function visProps(props) {
   } = props;
   let { xScale } = props;
 
-  const innerMargin = {
+  const padding = {
     top: 15,
-    right: innerMarginRight,
+    right: paddingRight,
     bottom: 10,
-    left: innerMarginLeft,
+    left: paddingLeft,
   };
 
-  const innerWidth = width - innerMargin.left - innerMargin.right;
-  const innerHeight = height - innerMargin.top - innerMargin.bottom;
+  const plotAreaWidth = width - padding.left - padding.right;
+  const plotAreaHeight = height - padding.top - padding.bottom;
 
   const xMin = 0;
-  const xMax = innerWidth;
-  const yMin = innerHeight;
+  const xMax = plotAreaWidth;
+  const yMin = plotAreaHeight;
   const yMax = 0;
 
   // set up the domains based on extent. Use the prop if provided, otherwise calculate
@@ -62,9 +62,9 @@ function visProps(props) {
 
   return {
     binWidth,
-    innerHeight,
-    innerMargin,
-    innerWidth,
+    plotAreaHeight,
+    padding,
+    plotAreaWidth,
     xScale,
     yScale,
   };
@@ -88,12 +88,12 @@ class CountChart extends PureComponent {
     highlightColor: PropTypes.string,
     highlightCount: PropTypes.any,
     highlightData: PropTypes.array,
-    innerHeight: PropTypes.number,
-    innerMargin: PropTypes.object,
-    innerWidth: PropTypes.number,
     maxBinWidth: React.PropTypes.number,
     numBins: PropTypes.number,
     onHighlightCount: PropTypes.func,
+    padding: PropTypes.object,
+    plotAreaHeight: PropTypes.number,
+    plotAreaWidth: PropTypes.number,
     width: PropTypes.number,
     xExtent: PropTypes.array,
     xKey: React.PropTypes.string,
@@ -139,7 +139,7 @@ class CountChart extends PureComponent {
    * Initialize the d3 chart - this is run once on mount
    */
   setup() {
-    const { width, height, innerMargin, innerHeight, innerWidth } = this.props;
+    const { width, height, padding, plotAreaHeight, plotAreaWidth } = this.props;
 
     // add in white background for saving as PNG
     d3.select(this.root).append('rect')
@@ -152,7 +152,7 @@ class CountChart extends PureComponent {
 
     this.g = d3.select(this.root)
       .append('g')
-      .attr('transform', `translate(${innerMargin.left} ${innerMargin.top})`);
+      .attr('transform', `translate(${padding.left} ${padding.top})`);
 
     // add in axis groups
     this.yAxis = this.g.append('g').classed('y-axis', true);
@@ -162,11 +162,11 @@ class CountChart extends PureComponent {
 
     // render a line for the x-axis (no ticks)
     this.xAxis = this.g.append('g').classed('x-axis', true)
-      .attr('transform', `translate(0 ${innerHeight})`);
+      .attr('transform', `translate(0 ${plotAreaHeight})`);
 
     this.xAxis.append('line')
       .attr('x1', 0)
-      .attr('x2', innerWidth);
+      .attr('x2', plotAreaWidth);
 
     // add in groups for data
     this.bars = this.g.append('g').classed('bars-group', true);
@@ -195,12 +195,12 @@ class CountChart extends PureComponent {
    * Render the x and y axis components
    */
   updateAxes() {
-    const { yScale, innerHeight, innerMargin } = this.props;
+    const { yScale, plotAreaHeight, padding } = this.props;
     const yAxis = d3.axisLeft(yScale).ticks(4).tickSizeOuter(0);
 
     this.yAxis.call(yAxis);
     this.yAxisLabel
-      .attr('transform', `rotate(270) translate(${-innerHeight / 2} ${-innerMargin.left + 12})`)
+      .attr('transform', `rotate(270) translate(${-plotAreaHeight / 2} ${-padding.left + 12})`)
       .text('Test Count');
   }
 
@@ -232,7 +232,7 @@ class CountChart extends PureComponent {
       yKey,
       yScale,
       binWidth,
-      innerHeight,
+      plotAreaHeight,
     } = this.props;
 
     const d3Color = d3.color(color);
@@ -263,7 +263,7 @@ class CountChart extends PureComponent {
       .attr('width', binWidth)
       .transition()
         .attr('y', d => yScale(d[yKey] || 0))
-        .attr('height', d => innerHeight - yScale(d[yKey] || 0))
+        .attr('height', d => plotAreaHeight - yScale(d[yKey] || 0))
         .style('fill', d => (d.belowThreshold ? '#fff' : lighterColor))
         .style('stroke', d => (d.belowThreshold ? '#ddd' : color));
 
@@ -285,7 +285,7 @@ class CountChart extends PureComponent {
       yKey,
       yScale,
       binWidth,
-      innerHeight,
+      plotAreaHeight,
     } = this.props;
 
     if (highlightCount == null) {
@@ -296,7 +296,7 @@ class CountChart extends PureComponent {
         .style('display', '')
         .attr('transform', `translate(${xScale(d[xKey])} ${yScale(d[yKey] || 0)})`);
 
-      const barHeight = innerHeight - yScale(d[yKey] || 0);
+      const barHeight = plotAreaHeight - yScale(d[yKey] || 0);
       this.highlightCountBar.select('rect')
         .attr('width', binWidth)
         .attr('height', barHeight)

--- a/src/components/Histogram/Histogram.jsx
+++ b/src/components/Histogram/Histogram.jsx
@@ -17,21 +17,21 @@ function visProps(props) {
     binWidth,
     width,
     height,
-    innerMarginLeft = 50,
-    innerMarginRight = 10,
-    innerMarginTop = 20,
+    paddingLeft = 50,
+    paddingRight = 10,
+    paddingTop = 20,
   } = props;
 
-  const innerMargin = {
-    top: innerMarginTop,
-    right: innerMarginRight,
+  const padding = {
+    top: paddingTop,
+    right: paddingRight,
     bottom: 40,
-    left: innerMarginLeft,
+    left: paddingLeft,
   };
 
   // Take into account the margins
-  const chartWidth = width - innerMargin.left - innerMargin.right;
-  const chartHeight = height - innerMargin.top - innerMargin.bottom;
+  const plotAreaWidth = width - padding.left - padding.right;
+  const plotAreaHeight = height - padding.top - padding.bottom;
 
   // Convert our bin stats to actual values
   const binEnd = (binStart) + (binWidth * (bins.length - 1));
@@ -40,22 +40,22 @@ function visProps(props) {
   // This is a histogram, so lets use a band scale.
   const xScale = d3.scaleBand()
     .domain(xValues)
-    .range([0, chartWidth]);
+    .range([0, plotAreaWidth]);
 
   let yDomain = yExtent;
   if (!yDomain) {
     yDomain = [0, d3.max(bins)];
   }
 
-  const yScale = d3.scaleLinear().range([chartHeight, 0]).clamp(true);
+  const yScale = d3.scaleLinear().range([plotAreaHeight, 0]).clamp(true);
   if (yDomain) {
     yScale.domain(yDomain);
   }
 
   return {
-    innerMargin,
-    chartWidth,
-    chartHeight,
+    padding,
+    plotAreaWidth,
+    plotAreaHeight,
     xValues,
     xScale,
     yScale,
@@ -79,12 +79,12 @@ class Histogram extends PureComponent {
     binStart: PropTypes.number,
     binWidth: PropTypes.number,
     bins: PropTypes.array,
-    chartHeight: PropTypes.number,
-    chartWidth: PropTypes.number,
     color: PropTypes.string,
     height: PropTypes.number,
     id: PropTypes.string,
-    innerMargin: PropTypes.object,
+    padding: PropTypes.object,
+    plotAreaHeight: PropTypes.number,
+    plotAreaWidth: PropTypes.number,
     width: PropTypes.number,
     xAxisLabel: PropTypes.string,
     xAxisUnit: PropTypes.string,
@@ -131,7 +131,7 @@ class Histogram extends PureComponent {
    * Initialize the d3 chart - this is run once on mount
    */
   setup() {
-    const { width, height } = this.props;
+    const { width, height, plotAreaWidth } = this.props;
 
     // add in white background for saving as PNG
     d3.select(this.root).append('rect')
@@ -149,7 +149,7 @@ class Histogram extends PureComponent {
     this.xAxis = this.g.append('g').classed('x-axis', true);
     this.xAxis.append('line')
       .attr('x1', 0)
-      .attr('x2', innerWidth);
+      .attr('x2', plotAreaWidth);
     this.xAxisLabel = this.g.append('text')
       .attr('dy', -4)
       .attr('class', 'axis-label')
@@ -171,8 +171,8 @@ class Histogram extends PureComponent {
    * Update the d3 chart - this is the main drawing function
    */
   update() {
-    const { innerMargin } = this.props;
-    this.g.attr('transform', `translate(${innerMargin.left} ${innerMargin.top})`);
+    const { padding } = this.props;
+    this.g.attr('transform', `translate(${padding.left} ${padding.top})`);
 
     this.updateAxes();
     this.updateBars();
@@ -182,8 +182,8 @@ class Histogram extends PureComponent {
    * Render the x and y axis components
    */
   updateAxes() {
-    const { xScale, xValues, yScale, yFormatter, chartHeight, chartWidth, innerMargin } = this.props;
-    const yTicks = Math.round(chartHeight / 50);
+    const { xScale, xValues, yScale, yFormatter, plotAreaHeight, plotAreaWidth, padding } = this.props;
+    const yTicks = Math.round(plotAreaHeight / 50);
     // show the first tick, then some afterwards.
     // TODO: should be moved out of histogram?
     const xTicks = xValues.filter((t, i) => i === 0 || mod(t, 12) === 0);
@@ -195,15 +195,15 @@ class Histogram extends PureComponent {
 
     this.yAxis.call(yAxis);
     this.yAxisLabel
-      .attr('transform', `rotate(270) translate(${-chartHeight / 2} ${-innerMargin.left + 12})`)
+      .attr('transform', `rotate(270) translate(${-plotAreaHeight / 2} ${-padding.left + 12})`)
       .text('Percentage of Tests');
 
     this.xAxis
-      .attr('transform', `translate(0 ${chartHeight})`)
+      .attr('transform', `translate(0 ${plotAreaHeight})`)
       .call(xAxis);
 
     this.xAxisLabel
-      .attr('transform', `translate(${chartWidth / 2} ${chartHeight + (innerMargin.bottom)})`)
+      .attr('transform', `translate(${plotAreaWidth / 2} ${plotAreaHeight + (padding.bottom)})`)
       .text(this.getXAxisLabel());
   }
 
@@ -216,7 +216,7 @@ class Histogram extends PureComponent {
       xScale,
       xValues,
       yScale,
-      chartHeight,
+      plotAreaHeight,
       color,
     } = this.props;
 
@@ -237,7 +237,7 @@ class Histogram extends PureComponent {
       .attr('width', xScale.bandwidth)
       .transition()
         .attr('y', d => yScale(d || 0))
-        .attr('height', d => chartHeight - yScale(d || 0))
+        .attr('height', d => plotAreaHeight - yScale(d || 0))
         .style('fill', color)
         .style('stroke', color);
 

--- a/src/components/HourChart/HourChart.jsx
+++ b/src/components/HourChart/HourChart.jsx
@@ -9,23 +9,23 @@ import './HourChart.scss';
  * based on the props of the component
  */
 function visProps(props) {
-  const { data, forceZeroMin, height, innerMarginLeft = 50, innerMarginRight = 20,
+  const { data, forceZeroMin, height, paddingLeft = 50, paddingRight = 20,
     width, yExtent, yKey } = props;
   let { xScale } = props;
 
-  const innerMargin = {
+  const padding = {
     top: 20,
-    right: innerMarginRight,
+    right: paddingRight,
     bottom: 40,
-    left: innerMarginLeft,
+    left: paddingLeft,
   };
 
-  const innerWidth = width - innerMargin.left - innerMargin.right;
-  const innerHeight = height - innerMargin.top - innerMargin.bottom;
+  const plotAreaWidth = width - padding.left - padding.right;
+  const plotAreaHeight = height - padding.top - padding.bottom;
 
   const xMin = 0;
-  const xMax = innerWidth;
-  const yMin = innerHeight;
+  const xMax = plotAreaWidth;
+  const yMin = plotAreaHeight;
   const yMax = 0;
 
   // set up the domains based on extent. Use the prop if provided, otherwise calculate
@@ -55,9 +55,9 @@ function visProps(props) {
     binWidth,
     data,
     height,
-    innerHeight,
-    innerMargin,
-    innerWidth,
+    plotAreaHeight,
+    padding,
+    plotAreaWidth,
     line,
     width,
     xScale,
@@ -96,14 +96,14 @@ class HourChart extends PureComponent {
     highlightHour: PropTypes.number,
     id: React.PropTypes.string,
     inSvg: React.PropTypes.bool,
-    innerHeight: PropTypes.number,
-    innerMargin: PropTypes.object,
-    innerMarginLeft: PropTypes.number,
-    innerMarginRight: PropTypes.number,
-    innerWidth: PropTypes.number,
     line: PropTypes.func,
     onHighlightHour: PropTypes.func,
     overallData: PropTypes.array,
+    padding: PropTypes.object,
+    paddingLeft: PropTypes.number,
+    paddingRight: PropTypes.number,
+    plotAreaHeight: PropTypes.number,
+    plotAreaWidth: PropTypes.number,
     threshold: PropTypes.number,
     width: PropTypes.number,
     xScale: React.PropTypes.func,
@@ -168,7 +168,7 @@ class HourChart extends PureComponent {
    * Initialize the d3 chart - this is run once on mount
    */
   setup() {
-    const { height, innerMargin, width } = this.props;
+    const { height, padding, width } = this.props;
 
     // add in white background for saving as PNG
     d3.select(this.root).append('rect')
@@ -181,7 +181,7 @@ class HourChart extends PureComponent {
 
     this.g = d3.select(this.root)
       .append('g')
-      .attr('transform', `translate(${innerMargin.left} ${innerMargin.top})`);
+      .attr('transform', `translate(${padding.left} ${padding.top})`);
 
     // add in axis groups
     this.xAxis = this.g.append('g').classed('x-axis', true);
@@ -260,7 +260,7 @@ class HourChart extends PureComponent {
    * Render the x and y axis components
    */
   updateAxes() {
-    const { xScale, yScale, innerHeight, innerWidth, innerMargin, binWidth, yKey, yFormatter } = this.props;
+    const { xScale, yScale, plotAreaHeight, plotAreaWidth, padding, binWidth, yKey, yFormatter } = this.props;
     const xAxis = d3.axisBottom(xScale).tickSizeOuter(0);
     const yAxis = d3.axisLeft(yScale).tickSizeOuter(0);
 
@@ -271,14 +271,14 @@ class HourChart extends PureComponent {
 
     this.yAxis.call(yAxis);
     this.yAxisLabel
-      .attr('transform', `rotate(270) translate(${-innerHeight / 2} ${-innerMargin.left + 12})`)
+      .attr('transform', `rotate(270) translate(${-plotAreaHeight / 2} ${-padding.left + 12})`)
       .text(this.getFullYAxisLabel());
 
     this.xAxis
-      .attr('transform', `translate(${binWidth / 2} ${innerHeight + 3})`)
+      .attr('transform', `translate(${binWidth / 2} ${plotAreaHeight + 3})`)
       .call(xAxis);
     this.xAxisLabel
-      .attr('transform', `translate(${innerWidth / 2} ${innerHeight + (innerMargin.bottom)})`)
+      .attr('transform', `translate(${plotAreaWidth / 2} ${plotAreaHeight + (padding.bottom)})`)
       .text('Hour');
   }
 
@@ -286,7 +286,7 @@ class HourChart extends PureComponent {
    * Render some circles in the chart
    */
   updateCircles() {
-    const { dataByHour, xScale, yScale, yKey, binWidth, color, innerHeight } = this.props;
+    const { dataByHour, xScale, yScale, yKey, binWidth, color, plotAreaHeight } = this.props;
 
     const binding = this.circles
       .selectAll('g')
@@ -311,7 +311,7 @@ class HourChart extends PureComponent {
           .attr('width', Math.ceil(binWidth))
           .attr('x', 0)
           .attr('y', 0)
-          .attr('height', innerHeight + 23);
+          .attr('height', plotAreaHeight + 23);
 
         // move selection over to the correct column.
         selection.attr('transform', `translate(${xScale(hour)} 0)`);

--- a/src/components/HourChart/HourChartWithCounts.jsx
+++ b/src/components/HourChart/HourChartWithCounts.jsx
@@ -73,14 +73,14 @@ function visProps(props) {
 
   const preparedData = prepareData(props);
 
-  const innerMargin = {
+  const padding = {
     right: 50,
     left: 50,
   };
-  const innerWidth = width - innerMargin.left - innerMargin.right;
+  const plotAreaWidth = width - padding.left - padding.right;
 
   const xMin = 0;
-  const xMax = innerWidth;
+  const xMax = plotAreaWidth;
 
   const xDomain = [0, 23];
   const xScale = d3.scaleLinear().domain(xDomain).range([xMin, xMax]);
@@ -88,7 +88,7 @@ function visProps(props) {
 
   return {
     ...preparedData,
-    innerMargin,
+    padding,
     numBins,
     xScale,
   };
@@ -120,10 +120,10 @@ class HourChartWithCounts extends PureComponent {
     forceZeroMin: PropTypes.bool,
     highlightHour: PropTypes.number,
     id: React.PropTypes.string,
-    innerMargin: PropTypes.object,
     numBins: PropTypes.number,
     onHighlightHour: PropTypes.func,
     overallData: PropTypes.array,
+    padding: PropTypes.object,
     threshold: PropTypes.number,
     width: PropTypes.number,
     xScale: React.PropTypes.func,
@@ -144,7 +144,7 @@ class HourChartWithCounts extends PureComponent {
    */
   render() {
     const { id, width, color, highlightHour, onHighlightHour, dataByHour, dataByDate,
-      filteredData, innerMargin, overallData, xScale, numBins } = this.props;
+      filteredData, padding, overallData, xScale, numBins } = this.props;
 
     const hourHeight = 250;
     const countHeight = 80;
@@ -170,8 +170,8 @@ class HourChartWithCounts extends PureComponent {
               id={undefined}
               inSvg
               height={hourHeight}
-              innerMarginLeft={innerMargin.left}
-              innerMarginRight={innerMargin.right}
+              paddingLeft={padding.left}
+              paddingRight={padding.right}
               xScale={xScale}
             />
           </g>
@@ -180,8 +180,8 @@ class HourChartWithCounts extends PureComponent {
               data={dataByHour}
               height={countHeight}
               highlightCount={highlightHour}
-              innerMarginLeft={innerMargin.left}
-              innerMarginRight={innerMargin.right}
+              paddingLeft={padding.left}
+              paddingRight={padding.right}
               numBins={numBins}
               onHighlightCount={onHighlightHour}
               width={width}

--- a/src/components/LineChart/LineChartWithCounts.jsx
+++ b/src/components/LineChart/LineChartWithCounts.jsx
@@ -51,14 +51,14 @@ function visProps(props) {
 
   const preparedData = prepareData(props);
   const { series } = preparedData;
-  const innerMargin = {
+  const padding = {
     right: 50,
     left: 50,
   };
-  const innerWidth = width - innerMargin.left - innerMargin.right;
+  const plotAreaWidth = width - padding.left - padding.right;
 
   const xMin = 0;
-  const xMax = innerWidth;
+  const xMax = plotAreaWidth;
 
   let xDomain = xExtent;
   if (!xDomain && series) {
@@ -81,8 +81,8 @@ function visProps(props) {
 
   return {
     series: preparedData.series,
-    counts: prepareData.counts,
-    innerMargin,
+    counts: preparedData.counts,
+    padding,
     numBins,
     xScale,
     colors,
@@ -125,10 +125,10 @@ class LineChartWithCounts extends PureComponent {
     highlightDate: React.PropTypes.object,
     highlightLine: React.PropTypes.object,
     id: React.PropTypes.string,
-    innerMargin: PropTypes.object,
     numBins: React.PropTypes.number,
     onHighlightDate: React.PropTypes.func,
     onHighlightLine: React.PropTypes.func,
+    padding: PropTypes.object,
     series: PropTypes.array,
     width: React.PropTypes.number,
     xExtent: PropTypes.array,
@@ -151,7 +151,7 @@ class LineChartWithCounts extends PureComponent {
    */
   render() {
     const { id, width, xKey, annotationSeries, series, highlightLine, highlightDate,
-      onHighlightDate, counts, innerMargin, xScale, numBins, colors } = this.props;
+      onHighlightDate, counts, padding, xScale, numBins, colors } = this.props;
 
     const lineChartHeight = 350;
     const countHeight = 80;
@@ -177,20 +177,20 @@ class LineChartWithCounts extends PureComponent {
               id={undefined}
               inSvg
               height={lineChartHeight}
-              innerMarginLeft={innerMargin.left}
-              innerMarginRight={innerMargin.right}
+              paddingLeft={padding.left}
+              paddingRight={padding.right}
               xScale={xScale}
             />
           </g>
           <g transform={`translate(0 ${lineChartHeight})`}>
             <CountChart
-              data={counts} /* TODO figure out multi-series counts */
+              data={counts}
               highlightData={highlightCountData}
               highlightCount={highlightDate}
               highlightColor={highlightColor}
               height={countHeight}
-              innerMarginLeft={innerMargin.left}
-              innerMarginRight={innerMargin.right}
+              paddingLeft={padding.left}
+              paddingRight={padding.right}
               onHighlightCount={onHighlightDate}
               numBins={numBins}
               width={width}

--- a/src/components/ScatterPlot/ScatterPlot.jsx
+++ b/src/components/ScatterPlot/ScatterPlot.jsx
@@ -22,16 +22,16 @@ function visProps(props) {
   } = props;
 
   const colors = colorsFor(data, (d) => d.id);
-  const innerMargin = {
+  const padding = {
     top: 40,
     right: 20,
     bottom: 40,
     left: 50,
   };
 
-  const chartWidth = width - innerMargin.left - innerMargin.right;
+  const plotAreaWidth = width - padding.left - padding.right;
 
-  const chartHeight = height - innerMargin.top - innerMargin.bottom;
+  const plotAreaHeight = height - padding.top - padding.bottom;
 
   let xDomain = xExtent;
   if (!xDomain && data) {
@@ -48,21 +48,21 @@ function visProps(props) {
     xDomain[0] = 0;
   }
 
-  const xScale = d3.scaleLinear().range([0, chartWidth]).clamp(true);
+  const xScale = d3.scaleLinear().range([0, plotAreaWidth]).clamp(true);
   if (xDomain) {
     xScale.domain(xDomain);
   }
 
-  const yScale = d3.scaleLinear().range([chartHeight, 0]).clamp(true);
+  const yScale = d3.scaleLinear().range([plotAreaHeight, 0]).clamp(true);
   if (yDomain) {
     yScale.domain(yDomain);
   }
 
   return {
     colors,
-    innerMargin,
-    chartWidth,
-    chartHeight,
+    padding,
+    plotAreaWidth,
+    plotAreaHeight,
     xScale,
     yScale,
   };
@@ -82,14 +82,14 @@ function visProps(props) {
  */
 class ScatterPlot extends PureComponent {
   static propTypes = {
-    chartHeight: PropTypes.number,
-    chartWidth: PropTypes.number,
     colors: PropTypes.object,
     data: PropTypes.array,
     height: PropTypes.number,
     id: React.PropTypes.string,
-    innerMargin: PropTypes.object,
     onHover: PropTypes.func,
+    padding: PropTypes.object,
+    plotAreaHeight: PropTypes.number,
+    plotAreaWidth: PropTypes.number,
     width: PropTypes.number,
     xAxisLabel: React.PropTypes.string,
     xAxisUnit: React.PropTypes.string,
@@ -177,7 +177,7 @@ class ScatterPlot extends PureComponent {
   updateChart() {
     const {
       data,
-      innerMargin,
+      padding,
       colors,
       xKey,
       xScale,
@@ -185,7 +185,7 @@ class ScatterPlot extends PureComponent {
       yScale,
     } = this.props;
 
-    this.g.attr('transform', `translate(${innerMargin.left} ${innerMargin.top})`);
+    this.g.attr('transform', `translate(${padding.left} ${padding.top})`);
 
     const binding = this.g.selectAll('.data-point').data(data, d => d.id);
     binding.exit().remove();
@@ -204,23 +204,23 @@ class ScatterPlot extends PureComponent {
    * Render the x and y axis components
    */
   updateAxes() {
-    const { xScale, yScale, chartHeight, chartWidth, innerMargin } = this.props;
+    const { xScale, yScale, plotAreaHeight, plotAreaWidth, padding } = this.props;
 
-    const xTicks = Math.round(chartWidth / 50);
-    const yTicks = Math.round(chartHeight / 50);
+    const xTicks = Math.round(plotAreaWidth / 50);
+    const yTicks = Math.round(plotAreaHeight / 50);
     const xAxis = d3.axisBottom(xScale).ticks(xTicks).tickSizeOuter(0);
     const yAxis = d3.axisLeft(yScale).ticks(yTicks).tickSizeOuter(0);
 
     this.yAxis.call(yAxis);
     this.yAxisLabel
-      .attr('transform', `rotate(270) translate(${-chartHeight / 2} ${-innerMargin.left + 12})`)
+      .attr('transform', `rotate(270) translate(${-plotAreaHeight / 2} ${-padding.left + 12})`)
       .text(this.getYAxisLabel());
 
     this.xAxis
-      .attr('transform', `translate(0 ${chartHeight + 3})`)
+      .attr('transform', `translate(0 ${plotAreaHeight + 3})`)
       .call(xAxis);
     this.xAxisLabel
-      .attr('transform', `translate(${chartWidth / 2} ${chartHeight + (innerMargin.bottom)})`)
+      .attr('transform', `translate(${plotAreaWidth / 2} ${plotAreaHeight + (padding.bottom)})`)
       .text(this.getXAxisLabel());
   }
 


### PR DESCRIPTION
As described in #94, use standard names for things in charts.

- innerWidth -> plotAreaWidth
- innerHeight -> plotAreaHeight
- innerMargin -> padding

Of note, LineChartSmallMults took a bit more work. I decided to rename additional variables:

- `chartHeight` -> `smallMultHeight`
- `chartWidth` -> `smallMultWidth`
- `chartPadding` -> `smallMultMargin` 

I did this to limit the confusion as to what chart applies to (the whole thing vs an individual chart). I could be swayed to keep them as `chart` if you think it's clear enough. I also think Margin makes more sense than Padding since it is describing the space between charts (outside of them).