### PR TITLE
Add Client ISP and Transit ISP filtering to Compare

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -187,8 +187,7 @@ export function getClientIspInfo(clientIspId) {
  * @return {Promise} A promise after the get request was made
  */
 export function getTransitIspSearch(searchQuery) {
-  // return get(`/server_asns/search/${searchQuery}`)
-  return get(`/client_asns/search/${searchQuery}`)
+  return get(`/server_asns/search/${searchQuery}`)
     .then(transform(transformTransitIspSearchResults));
 }
 

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -3,7 +3,8 @@ import {
   transform,
   transformTimeSeries,
   transformHourly,
-  transformSearchResults,
+  transformLocationSearchResults,
+  transformClientIspSearchResults,
   transformClientIspLabel,
   transformLocationInfo,
   transformLocationLabel,
@@ -136,7 +137,7 @@ export function getLocationTopClientIsps(locationId) {
  */
 export function getLocationSearch(searchQuery) {
   return get(`/locations/search/${searchQuery}`)
-    .then(transform(transformSearchResults));
+    .then(transform(transformLocationSearchResults));
 }
 
 /**
@@ -149,4 +150,16 @@ export function getLocationSearch(searchQuery) {
 export function getLocationClientIspInfo(locationId, clientIspId) {
   return get(`/locations/${locationId}/clientisps/${clientIspId}/info`)
     .then(transform(transformFixedData));
+}
+
+
+/**
+ * Get Search results for a client ISP
+ *
+ * @param {String} searchQuery search to search for.
+ * @return {Promise} A promise after the get request was made
+ */
+export function getClientIspSearch(searchQuery) {
+  return get(`/client_asns/search/${searchQuery}`)
+    .then(transform(transformClientIspSearchResults));
 }

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -11,6 +11,8 @@ import {
   transformLocationLabel,
   transformFixedData,
   transformMapMeta,
+  transformTransitIspSearchResults,
+  transformTransitIspInfo,
 } from './transforms';
 
 const DATE_FORMATS = {
@@ -175,5 +177,30 @@ export function getClientIspInfo(clientIspId) {
   // return get(`/client_asns/${clientIspId}/info`)
   return get('/locations/nauswa/info')
     .then(transform(transformClientIspInfo(clientIspId)));
+}
+
+
+/**
+ * Get Search results for a transit ISP
+ *
+ * @param {String} searchQuery search to search for. (e.g. comcas)
+ * @return {Promise} A promise after the get request was made
+ */
+export function getTransitIspSearch(searchQuery) {
+  // return get(`/server_asns/search/${searchQuery}`)
+  return get(`/client_asns/search/${searchQuery}`)
+    .then(transform(transformTransitIspSearchResults));
+}
+
+/**
+ * Get information for a transit ISP
+ *
+ * @param {String} transitIspId The transit ISP to query (e.g., AS7922)
+ * @return {Promise} A promise after the get request was made
+ */
+export function getTransitIspInfo(transitIspId) {
+  // return get(`/server_asns/${clientIspId}/info`)
+  return get('/locations/nauswa/info')
+    .then(transform(transformTransitIspInfo(transitIspId)));
 }
 

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -6,6 +6,7 @@ import {
   transformLocationSearchResults,
   transformClientIspSearchResults,
   transformClientIspLabel,
+  transformClientIspInfo,
   transformLocationInfo,
   transformLocationLabel,
   transformFixedData,
@@ -171,6 +172,8 @@ export function getClientIspSearch(searchQuery) {
  * @return {Promise} A promise after the get request was made
  */
 export function getClientIspInfo(clientIspId) {
-  return get(`/client_asns/${clientIspId}/info`);
+  // return get(`/client_asns/${clientIspId}/info`)
+  return get('/locations/nauswa/info')
+    .then(transform(transformClientIspInfo(clientIspId)));
 }
 

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -156,10 +156,21 @@ export function getLocationClientIspInfo(locationId, clientIspId) {
 /**
  * Get Search results for a client ISP
  *
- * @param {String} searchQuery search to search for.
+ * @param {String} searchQuery search to search for. (e.g. comcas)
  * @return {Promise} A promise after the get request was made
  */
 export function getClientIspSearch(searchQuery) {
   return get(`/client_asns/search/${searchQuery}`)
     .then(transform(transformClientIspSearchResults));
 }
+
+/**
+ * Get information for a client ISP
+ *
+ * @param {String} clientIspId The client ISP to query (e.g., AS7922)
+ * @return {Promise} A promise after the get request was made
+ */
+export function getClientIspInfo(clientIspId) {
+  return get(`/client_asns/${clientIspId}/info`);
+}
+

--- a/src/api/transforms.js
+++ b/src/api/transforms.js
@@ -125,12 +125,12 @@ export function transformHourly(body) {
 console.warn('TODO - temporarily adding in ID in transform search results');
 
 /**
- * Transforms the response from search before rest of application uses it.
+ * Transforms the response from location search before rest of application uses it.
  *
  * @param {Object} body The response body
  * @return {Object} The transformed response body
  */
-export function transformSearchResults(body) {
+export function transformLocationSearchResults(body) {
   // NOTE: modifying body directly means it modifies what is stored in the API cache
   if (body.results) {
     const results = body.results;
@@ -152,13 +152,34 @@ export function transformSearchResults(body) {
     });
 
     // add new entries to the body object
-    Object.assign(body, {
-      results,
-    });
+    body.results = results;
   } else {
-    Object.assign(body, {
-      results: [],
+    body.resuts = [];
+  }
+
+  return body;
+}
+
+/**
+ * Transforms the response from clientIsp search before rest of application uses it.
+ *
+ * @param {Object} body The response body
+ * @return {Object} The transformed response body
+ */
+export function transformClientIspSearchResults(body) {
+  // NOTE: modifying body directly means it modifies what is stored in the API cache
+  if (body.results) {
+    const results = body.results;
+    results.forEach(d => {
+      console.log('setting label on ', d);
+      d.meta.label = d.meta.client_asn_name;
+      d.meta.id = d.meta.client_asn_number;
     });
+
+    // add new entries to the body object
+    body.results = results;
+  } else {
+    body.resuts = [];
   }
 
   return body;

--- a/src/api/transforms.js
+++ b/src/api/transforms.js
@@ -171,7 +171,6 @@ export function transformClientIspSearchResults(body) {
   if (body.results) {
     const results = body.results;
     results.forEach(d => {
-      console.log('setting label on ', d);
       d.meta.label = d.meta.client_asn_name;
       d.meta.id = d.meta.client_asn_number;
     });

--- a/src/api/transforms.js
+++ b/src/api/transforms.js
@@ -122,6 +122,36 @@ export function transformHourly(body) {
   return body;
 }
 
+/**
+ * Transforms location meta to have label
+ *
+ * - adds in a `label` property to meta
+ *
+ * @param {Object} body The response body
+ * @return {Object} The transformed response body
+ */
+export function transformLocationLabel(body) {
+  // NOTE: modifying body directly means it modifies what is stored in the API cache
+  if (body.meta) {
+    const { meta } = body;
+
+    meta.label = meta.client_city || meta.client_region || meta.client_country || meta.client_continent;
+    meta.longLabel = meta.label;
+    // Create a display name for locations.
+    if (meta.type === 'city') {
+      if (meta.client_country === 'United States') {
+        meta.longLabel += `, ${meta.client_region}`;
+      } else {
+        meta.longLabel += `, ${meta.client_country}`;
+      }
+    } else if (meta.type === 'region') {
+      meta.longLabel += `, ${meta.client_country}`;
+    }
+  }
+
+  return body;
+}
+
 console.warn('TODO - temporarily adding in ID in transform search results');
 
 /**
@@ -136,18 +166,9 @@ export function transformLocationSearchResults(body) {
     const results = body.results;
     results.forEach(d => {
       // Create a display name for cities.
-      d.name = d.meta.location;
-      if (d.meta.type === 'city') {
-        if (d.meta.client_country === 'United States') {
-          d.name += `, ${d.meta.client_region}`;
-        } else {
-          d.name += `, ${d.meta.client_country}`;
-        }
-      } else if (d.meta.type === 'region') {
-        d.name += `, ${d.meta.client_country}`;
-      }
+      transformLocationLabel(d);
+      d.name = d.meta.longLabel;
       d.id = d.meta.location_key;
-      d.meta.label = d.name;
       d.meta.id = d.meta.location_key;
     });
 
@@ -183,27 +204,6 @@ export function transformClientIspSearchResults(body) {
 
   return body;
 }
-
-
-/**
- * Transforms location meta to have label
- *
- * - adds in a `label` property to meta
- *
- * @param {Object} body The response body
- * @return {Object} The transformed response body
- */
-export function transformLocationLabel(body) {
-  // NOTE: modifying body directly means it modifies what is stored in the API cache
-  if (body.meta) {
-    const { meta } = body;
-
-    meta.label = meta.client_city || meta.client_region || meta.client_country || meta.client_continent;
-  }
-
-  return body;
-}
-
 
 /**
  * Transforms client ISP meta to have label

--- a/src/api/transforms.js
+++ b/src/api/transforms.js
@@ -371,3 +371,26 @@ export function transformMapMeta(body) {
 
   return body;
 }
+
+/**
+ * Transforms the response from client ISP info before passing it into
+ * the application.
+ *
+ * @param {Object} body The response body
+ * @return {Object} The transformed response body
+ */
+export function transformClientIspInfo(clientIspId) {
+  // NOTE: modifying body directly means it modifies what is stored in the API cache
+  return function fakeTransform(body) {
+    if (body.meta) {
+      body.meta = {
+        client_asn_name: 'Client ISP Name',
+        client_asn_number: clientIspId,
+        id: clientIspId,
+        label: 'Client ISP Name',
+      };
+    }
+
+    return body;
+  };
+}

--- a/src/api/transforms.js
+++ b/src/api/transforms.js
@@ -216,11 +216,8 @@ export function transformTransitIspSearchResults(body) {
   if (body.results) {
     const results = body.results;
     results.forEach(d => {
-      d.meta.server_asn_name = d.meta.client_asn_name; // TODO should not be using clients
-      d.meta.id = d.meta.server_asn_name.toLowerCase().replace(/ /g, ''); // TODO should have ID...
-
+      d.meta.id = d.meta.server_asn_name_lookup; // TODO - this should eventually be provided as `id`
       d.meta.label = d.meta.server_asn_name;
-      d.meta.id = d.meta.id;
     });
 
     // add new entries to the body object

--- a/src/api/transforms.js
+++ b/src/api/transforms.js
@@ -206,6 +206,33 @@ export function transformClientIspSearchResults(body) {
 }
 
 /**
+ * Transforms the response from transitIsp search before rest of application uses it.
+ *
+ * @param {Object} body The response body
+ * @return {Object} The transformed response body
+ */
+export function transformTransitIspSearchResults(body) {
+  // NOTE: modifying body directly means it modifies what is stored in the API cache
+  if (body.results) {
+    const results = body.results;
+    results.forEach(d => {
+      d.meta.server_asn_name = d.meta.client_asn_name; // TODO should not be using clients
+      d.meta.id = d.meta.server_asn_name.toLowerCase().replace(/ /g, ''); // TODO should have ID...
+
+      d.meta.label = d.meta.server_asn_name;
+      d.meta.id = d.meta.id;
+    });
+
+    // add new entries to the body object
+    body.results = results;
+  } else {
+    body.resuts = [];
+  }
+
+  return body;
+}
+
+/**
  * Transforms client ISP meta to have label
  *
  * - adds in a `label` property to meta
@@ -388,6 +415,29 @@ export function transformClientIspInfo(clientIspId) {
         client_asn_number: clientIspId,
         id: clientIspId,
         label: 'Client ISP Name',
+      };
+    }
+
+    return body;
+  };
+}
+
+
+/**
+ * Transforms the response from transit ISP info before passing it into
+ * the application.
+ *
+ * @param {Object} body The response body
+ * @return {Object} The transformed response body
+ */
+export function transformTransitIspInfo(transitIspId) {
+  // NOTE: modifying body directly means it modifies what is stored in the API cache
+  return function fakeTransform(body) {
+    if (body.meta) {
+      body.meta = {
+        server_asn_name: 'Transit ISP Name',
+        id: transitIspId,
+        label: 'Transit ISP Name',
       };
     }
 

--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -14,6 +14,7 @@ import './Search.scss';
 class Search extends PureComponent {
   static propTypes = {
     className: PropTypes.string,
+    defaultSectionName: PropTypes.string,
     onSearchChange: PropTypes.func,
     onSuggestionSelected: PropTypes.func,
     placeholder: PropTypes.string,
@@ -25,6 +26,7 @@ class Search extends PureComponent {
     placeholder: 'Search',
     searchQuery: '',
     searchResults: [],
+    defaultSectionName: 'Other',
   }
 
   /**
@@ -130,8 +132,10 @@ class Search extends PureComponent {
   * @return {String} search term we are searching for
   */
   formatSuggestions(results) {
+    const { defaultSectionName } = this.props;
+
     const nest = d3.nest()
-      .key((d) => d.meta.type)
+      .key((d) => d.meta.type || defaultSectionName)
       .entries(results);
     return nest;
   }
@@ -154,7 +158,7 @@ class Search extends PureComponent {
     return (
       <div>
         <span className="suggestion-count">{formatNumber(suggestion.data.test_count)}</span>
-        <span className="suggestion-name">{suggestion.meta.label}</span>
+        <span className="suggestion-name">{suggestion.meta.longLabel || suggestion.meta.label}</span>
       </div>
     );
   }

--- a/src/components/Search/Search.jsx
+++ b/src/components/Search/Search.jsx
@@ -122,7 +122,7 @@ class Search extends PureComponent {
   * @param {Object} suggestion Suggestion selected
   */
   getSuggestionValue(suggestion) {
-    return suggestion.name;
+    return suggestion.meta.label;
   }
 
   /**
@@ -154,7 +154,7 @@ class Search extends PureComponent {
     return (
       <div>
         <span className="suggestion-count">{formatNumber(suggestion.data.test_count)}</span>
-        <span className="suggestion-name">{suggestion.name}</span>
+        <span className="suggestion-name">{suggestion.meta.label}</span>
       </div>
     );
   }

--- a/src/components/SearchSelect/SearchSelect.jsx
+++ b/src/components/SearchSelect/SearchSelect.jsx
@@ -3,9 +3,9 @@ import Row from 'react-bootstrap/lib/Row';
 import Col from 'react-bootstrap/lib/Col';
 
 import { Icon } from '../../components';
-import { LocationSearch } from '../../containers';
+import { LocationSearch, ClientIspSearch } from '../../containers';
 
-import { colorsFor, hashString } from '../../utils/color';
+import { colorsFor, hashAsn, hashString } from '../../utils/color';
 
 import '../../assets/react-select.scss';
 import './SearchSelect.scss';
@@ -18,11 +18,13 @@ import './SearchSelect.scss';
 export default class SearchSelect extends PureComponent {
   static propTypes = {
     onChange: PropTypes.func,
+    orientation: PropTypes.oneOf(['horizontal', 'vertical']),
     selected: PropTypes.array,
-    type: PropTypes.string,
+    type: PropTypes.oneOf(['location', 'clientIsp', 'transitIsp']),
   }
 
   static defaultProps = {
+    orientation: 'horizontal',
     selected: [],
   }
 
@@ -59,6 +61,12 @@ export default class SearchSelect extends PureComponent {
     }
   }
 
+  getColors(selected) {
+    const { type } = this.props;
+    const hash = type === 'clientIsp' ? hashAsn : hashString;
+    return colorsFor(selected, (d) => d.id, hash);
+  }
+
   /**
    * Render individual selected item
    * @return {React.Component}
@@ -82,7 +90,7 @@ export default class SearchSelect extends PureComponent {
    * @return {React.Component}
    */
   renderSelectedItems(selected) {
-    const colors = colorsFor(selected, (d) => d.id, hashString);
+    const colors = this.getColors(selected);
     return (
       <div className="active-items">
         {selected.map((item) =>
@@ -97,15 +105,24 @@ export default class SearchSelect extends PureComponent {
    * @return {React.Component} The rendered component
    */
   render() {
-    const { selected } = this.props;
+    const { type, selected, orientation } = this.props;
+    const colSize = orientation === 'vertical' ? 12 : 6;
+
+    // decide which search component to use based on type
+    let SearchComponent;
+    if (type === 'clientIsp') {
+      SearchComponent = ClientIspSearch;
+    } else {
+      SearchComponent = LocationSearch;
+    }
 
     return (
       <div className="SearchSelect">
         <Row>
-          <Col md={6}>
-            <LocationSearch onSuggestionSelected={this.onAdd} />
+          <Col md={colSize}>
+            <SearchComponent onSuggestionSelected={this.onAdd} />
           </Col>
-          <Col md={6}>
+          <Col md={colSize}>
             {this.renderSelectedItems(selected)}
           </Col>
         </Row>

--- a/src/components/SearchSelect/SearchSelect.jsx
+++ b/src/components/SearchSelect/SearchSelect.jsx
@@ -3,7 +3,7 @@ import Row from 'react-bootstrap/lib/Row';
 import Col from 'react-bootstrap/lib/Col';
 
 import { Icon } from '../../components';
-import { LocationSearch, ClientIspSearch } from '../../containers';
+import { LocationSearch, ClientIspSearch, TransitIspSearch } from '../../containers';
 
 import { colorsFor, hashAsn, hashString } from '../../utils/color';
 
@@ -112,6 +112,8 @@ export default class SearchSelect extends PureComponent {
     let SearchComponent;
     if (type === 'clientIsp') {
       SearchComponent = ClientIspSearch;
+    } else if (type === 'transitIsp') {
+      SearchComponent = TransitIspSearch;
     } else {
       SearchComponent = LocationSearch;
     }

--- a/src/components/SearchSelect/SearchSelect.jsx
+++ b/src/components/SearchSelect/SearchSelect.jsx
@@ -120,7 +120,7 @@ export default class SearchSelect extends PureComponent {
       <div className="SearchSelect">
         <Row>
           <Col md={colSize}>
-            <SearchComponent onSuggestionSelected={this.onAdd} />
+            <SearchComponent onSuggestionSelected={this.onAdd} exclude={selected} />
           </Col>
           <Col md={colSize}>
             {this.renderSelectedItems(selected)}

--- a/src/components/SearchSelect/SearchSelect.jsx
+++ b/src/components/SearchSelect/SearchSelect.jsx
@@ -75,7 +75,7 @@ export default class SearchSelect extends PureComponent {
     const style = { backgroundColor: color };
     return (
       <div key={item.id} className="selected-item" style={style}>
-        <span className="item-label">{item.label}</span>
+        <span className="item-label">{item.longLabel || item.label}</span>
         <Icon
           name="close"
           className="item-remove-control"

--- a/src/containers/ClientIspSearch/ClientIspSearch.jsx
+++ b/src/containers/ClientIspSearch/ClientIspSearch.jsx
@@ -6,15 +6,16 @@ import * as GlobalSearchSelectors from '../../redux/globalSearch/selectors';
 
 import { Search } from '../../components';
 
-function mapStateToProps(state) {
+function mapStateToProps(state, props) {
   return {
-    searchResults: GlobalSearchSelectors.getClientIspSearchResults(state),
+    searchResults: GlobalSearchSelectors.getClientIspSearchResults(state, props),
   };
 }
 
 class ClientIspSearch extends PureComponent {
   static propTypes = {
     dispatch: PropTypes.func,
+    exclude: PropTypes.array,
     onSuggestionSelected: PropTypes.func,
     router: PropTypes.object,
     searchResults: PropTypes.array,

--- a/src/containers/ClientIspSearch/ClientIspSearch.jsx
+++ b/src/containers/ClientIspSearch/ClientIspSearch.jsx
@@ -8,11 +8,11 @@ import { Search } from '../../components';
 
 function mapStateToProps(state) {
   return {
-    searchResults: GlobalSearchSelectors.getLocationSearchResults(state),
+    searchResults: GlobalSearchSelectors.getClientIspSearchResults(state),
   };
 }
 
-class LocationSearch extends PureComponent {
+class ClientIspSearch extends PureComponent {
   static propTypes = {
     dispatch: PropTypes.func,
     onSuggestionSelected: PropTypes.func,
@@ -25,19 +25,6 @@ class LocationSearch extends PureComponent {
 
     // bind handlers
     this.onSearchQueryChange = this.onSearchQueryChange.bind(this);
-    this.onSuggestionSelected = this.onSuggestionSelected.bind(this);
-  }
-
-  /**
-   * Default is to navigate to the location page. This is only used
-   * if no `onSuggestionSelected` prop is passed in.
-   */
-  onSuggestionSelected(suggestion) {
-    const { router } = this.props;
-
-    const suggestionId = suggestion.id;
-    const path = `/location/${suggestionId}`;
-    router.push(path);
   }
 
   /**
@@ -45,21 +32,22 @@ class LocationSearch extends PureComponent {
    */
   onSearchQueryChange(query) {
     const { dispatch } = this.props;
-    dispatch(GlobalSearchActions.fetchLocationSearchIfNeeded(query));
+    dispatch(GlobalSearchActions.fetchClientIspSearchIfNeeded(query));
   }
 
   render() {
     const { searchResults, onSuggestionSelected } = this.props;
+
     return (
       <Search
-        className="LocationSearch"
-        placeholder="Search for a location"
+        className="ClientIspSearch"
+        placeholder="Search for a client ISP"
         searchResults={searchResults}
         onSearchChange={this.onSearchQueryChange}
-        onSuggestionSelected={onSuggestionSelected || this.onSuggestionSelected}
+        onSuggestionSelected={onSuggestionSelected}
       />
     );
   }
 }
 
-export default connect(mapStateToProps)(withRouter(LocationSearch));
+export default connect(mapStateToProps)(withRouter(ClientIspSearch));

--- a/src/containers/ComparePage/ComparePage.jsx
+++ b/src/containers/ComparePage/ComparePage.jsx
@@ -10,9 +10,10 @@ import * as ComparePageSelectors from '../../redux/comparePage/selectors';
 import * as ComparePageActions from '../../redux/comparePage/actions';
 import * as LocationsActions from '../../redux/locations/actions';
 import * as ClientIspsActions from '../../redux/clientIsps/actions';
+import * as TransitIspsActions from '../../redux/transitIsps/actions';
 
-import { colorsFor } from '../../utils/color';
-import { metrics, facetTypes } from '../../constants';
+// import { colorsFor } from '../../utils/color';
+import { facetTypes } from '../../constants';
 
 import {
   DateRangeSelector,
@@ -39,6 +40,7 @@ const urlQueryConfig = {
   timeAggregation: { type: 'string', defaultValue: 'day', urlKey: 'aggr' },
   facetLocationIds: { type: 'array', urlKey: 'locations' },
   filterClientIspIds: { type: 'array', urlKey: 'filterClientIsps' },
+  filterTransitIspIds: { type: 'array', urlKey: 'filterTransitIsps' },
 };
 const urlHandler = new UrlHandler(urlQueryConfig, browserHistory);
 
@@ -48,6 +50,7 @@ function mapStateToProps(state, propsWithUrl) {
     facetLocationInfos: ComparePageSelectors.getFacetLocationInfos(state, propsWithUrl),
     facetType: ComparePageSelectors.getFacetType(state, propsWithUrl),
     filterClientIspInfos: ComparePageSelectors.getFilterClientIspInfos(state, propsWithUrl),
+    filterTransitIspInfos: ComparePageSelectors.getFilterTransitIspInfos(state, propsWithUrl),
     viewMetric: ComparePageSelectors.getViewMetric(state, propsWithUrl),
   };
 }
@@ -62,6 +65,8 @@ class ComparePage extends PureComponent {
     facetType: PropTypes.object,
     filterClientIspIds: PropTypes.array,
     filterClientIspInfos: PropTypes.array,
+    filterTransitIspIds: PropTypes.array,
+    filterTransitIspInfos: PropTypes.array,
     startDate: momentPropTypes.momentObj,
     timeAggregation: PropTypes.string,
     viewMetric: PropTypes.object,
@@ -75,6 +80,7 @@ class ComparePage extends PureComponent {
     this.onFacetTypeChange = this.onFacetTypeChange.bind(this);
     this.onFacetLocationsChange = this.onFacetLocationsChange.bind(this);
     this.onFilterClientIspsChange = this.onFilterClientIspsChange.bind(this);
+    this.onFilterTransitIspsChange = this.onFilterTransitIspsChange.bind(this);
     this.onTimeAggregationChange = this.onTimeAggregationChange.bind(this);
     this.onViewMetricChange = this.onViewMetricChange.bind(this);
   }
@@ -91,7 +97,7 @@ class ComparePage extends PureComponent {
    * Fetch the data for the page if needed
    */
   fetchData(props) {
-    const { dispatch, facetLocationIds, filterClientIspIds } = props;
+    const { dispatch, facetLocationIds, filterClientIspIds, filterTransitIspIds } = props;
 
     // get facet location info if needed
     if (facetLocationIds) {
@@ -104,6 +110,13 @@ class ComparePage extends PureComponent {
     if (filterClientIspIds) {
       filterClientIspIds.forEach(filterClientIspId => {
         dispatch(ClientIspsActions.fetchInfoIfNeeded(filterClientIspId));
+      });
+    }
+
+    // get filter transit ISP info if needed
+    if (filterTransitIspIds) {
+      filterTransitIspIds.forEach(filterTransitIspId => {
+        dispatch(TransitIspsActions.fetchInfoIfNeeded(filterTransitIspId));
       });
     }
   }
@@ -165,6 +178,15 @@ class ComparePage extends PureComponent {
     dispatch(ComparePageActions.changeFilterClientIsps(clientIsps, dispatch));
   }
 
+  /**
+   * Callback when the filter transit ISP list changes
+   * @param {Array} transitIsps array of transit ISP info objects
+   */
+  onFilterTransitIspsChange(transitIsps) {
+    const { dispatch } = this.props;
+    dispatch(ComparePageActions.changeFilterTransitIsps(transitIsps, dispatch));
+  }
+
   renderTimeRangeSelector() {
     const { startDate, endDate } = this.props;
 
@@ -205,7 +227,7 @@ class ComparePage extends PureComponent {
   }
 
   renderLocationInputs() {
-    const { facetLocationInfos, filterClientIspInfos } = this.props;
+    const { facetLocationInfos, filterClientIspInfos, filterTransitIspInfos } = this.props;
 
     return (
       <div className="input-section subsection">
@@ -230,7 +252,12 @@ class ComparePage extends PureComponent {
           <Col md={6}>
             <h4>Filter by Transit ISP</h4>
             <p>Select one or more Transit ISPs to filter the measurements by.</p>
-            <input className="form-control" type="text" />
+            <SearchSelect
+              type="transitIsp"
+              orientation="vertical"
+              onChange={this.onFilterTransitIspsChange}
+              selected={filterTransitIspInfos}
+            />
           </Col>
         </Row>
       </div>

--- a/src/containers/ComparePage/ComparePage.jsx
+++ b/src/containers/ComparePage/ComparePage.jsx
@@ -41,14 +41,16 @@ const urlQueryConfig = {
   endDate: { type: 'date', urlKey: 'end', defaultValue: moment('2015-11-1') },
   timeAggregation: { type: 'string', defaultValue: 'day', urlKey: 'aggr' },
   facetLocationIds: { type: 'array', urlKey: 'locations' },
+  filterClientIspIds: { type: 'array', urlKey: 'filterClientIsps' },
 };
 const urlHandler = new UrlHandler(urlQueryConfig, browserHistory);
 
 function mapStateToProps(state, propsWithUrl) {
   return {
     ...propsWithUrl,
-    facetLocationInfos: ComparePageSelectors.getFacetLocationInfo(state, propsWithUrl),
+    facetLocationInfos: ComparePageSelectors.getFacetLocationInfos(state, propsWithUrl),
     facetType: ComparePageSelectors.getFacetType(state, propsWithUrl),
+    filterClientIspInfos: ComparePageSelectors.getFilterClientIspInfos(state, propsWithUrl),
     viewMetric: ComparePageSelectors.getViewMetric(state, propsWithUrl),
   };
 }
@@ -61,6 +63,8 @@ class ComparePage extends PureComponent {
     facetLocationIds: PropTypes.array,
     facetLocationInfos: PropTypes.array,
     facetType: PropTypes.object,
+    filterClientIspIds: PropTypes.array,
+    filterClientIspInfos: PropTypes.array,
     startDate: momentPropTypes.momentObj,
     timeAggregation: PropTypes.string,
     viewMetric: PropTypes.object,
@@ -70,9 +74,10 @@ class ComparePage extends PureComponent {
     super(props);
 
     // bind handlers
-    this.onFacetTypeChange = this.onFacetTypeChange.bind(this);
     this.onDateRangeChange = this.onDateRangeChange.bind(this);
+    this.onFacetTypeChange = this.onFacetTypeChange.bind(this);
     this.onFacetLocationsChange = this.onFacetLocationsChange.bind(this);
+    this.onFilterClientIspsChange = this.onFilterClientIspsChange.bind(this);
     this.onTimeAggregationChange = this.onTimeAggregationChange.bind(this);
     this.onViewMetricChange = this.onViewMetricChange.bind(this);
   }
@@ -131,9 +136,22 @@ class ComparePage extends PureComponent {
     }
   }
 
+  /**
+   * Callback when the facet location list changes
+   * @param {Array} facetLocations array of location info objects
+   */
   onFacetLocationsChange(facetLocations) {
     const { dispatch } = this.props;
     dispatch(ComparePageActions.changeFacetLocations(facetLocations, dispatch));
+  }
+
+  /**
+   * Callback when the filter client ISP list changes
+   * @param {Array} clientIsps array of client ISP info objects
+   */
+  onFilterClientIspsChange(clientIsps) {
+    const { dispatch } = this.props;
+    dispatch(ComparePageActions.changeFilterClientIsps(clientIsps, dispatch));
   }
 
   renderTimeRangeSelector() {
@@ -176,7 +194,7 @@ class ComparePage extends PureComponent {
   }
 
   renderLocationInputs() {
-    const { facetLocationInfos } = this.props;
+    const { facetLocationInfos, filterClientIspInfos } = this.props;
 
     return (
       <div className="input-section subsection">
@@ -191,7 +209,12 @@ class ComparePage extends PureComponent {
           <Col md={6}>
             <h4>Filter by Client ISP</h4>
             <p>Select one or more Client ISPs to filter the measurements by.</p>
-            <input className="form-control" type="text" />
+            <SearchSelect
+              type="clientIsp"
+              orientation="vertical"
+              onChange={this.onFilterClientIspsChange}
+              selected={filterClientIspInfos}
+            />
           </Col>
           <Col md={6}>
             <h4>Filter by Transit ISP</h4>

--- a/src/containers/ComparePage/ComparePage.jsx
+++ b/src/containers/ComparePage/ComparePage.jsx
@@ -8,7 +8,6 @@ import Col from 'react-bootstrap/lib/Col';
 
 import * as ComparePageSelectors from '../../redux/comparePage/selectors';
 import * as ComparePageActions from '../../redux/comparePage/actions';
-// import * as LocationsActions from '../../redux/locations/actions';
 
 import { colorsFor } from '../../utils/color';
 import { metrics, facetTypes } from '../../constants';
@@ -20,10 +19,6 @@ import {
   TimeAggregationSelector,
   SearchSelect,
 } from '../../components';
-
-import {
-  LocationSearch,
-} from '../../containers';
 
 import UrlHandler from '../../url/UrlHandler';
 import urlConnect from '../../url/urlConnect';

--- a/src/containers/ComparePage/ComparePage.jsx
+++ b/src/containers/ComparePage/ComparePage.jsx
@@ -9,6 +9,7 @@ import Col from 'react-bootstrap/lib/Col';
 import * as ComparePageSelectors from '../../redux/comparePage/selectors';
 import * as ComparePageActions from '../../redux/comparePage/actions';
 import * as LocationsActions from '../../redux/locations/actions';
+import * as ClientIspsActions from '../../redux/clientIsps/actions';
 
 import { colorsFor } from '../../utils/color';
 import { metrics, facetTypes } from '../../constants';
@@ -90,12 +91,19 @@ class ComparePage extends PureComponent {
    * Fetch the data for the page if needed
    */
   fetchData(props) {
-    const { dispatch, facetLocationIds } = props;
+    const { dispatch, facetLocationIds, filterClientIspIds } = props;
 
-    // get location info if needed
+    // get facet location info if needed
     if (facetLocationIds) {
       facetLocationIds.forEach(facetLocationId => {
         dispatch(LocationsActions.fetchInfoIfNeeded(facetLocationId));
+      });
+    }
+
+    // get filter client ISP info if needed
+    if (filterClientIspIds) {
+      filterClientIspIds.forEach(filterClientIspId => {
+        dispatch(ClientIspsActions.fetchInfoIfNeeded(filterClientIspId));
       });
     }
   }

--- a/src/containers/ComparePage/ComparePage.jsx
+++ b/src/containers/ComparePage/ComparePage.jsx
@@ -8,6 +8,7 @@ import Col from 'react-bootstrap/lib/Col';
 
 import * as ComparePageSelectors from '../../redux/comparePage/selectors';
 import * as ComparePageActions from '../../redux/comparePage/actions';
+import * as LocationsActions from '../../redux/locations/actions';
 
 import { colorsFor } from '../../utils/color';
 import { metrics, facetTypes } from '../../constants';
@@ -89,7 +90,14 @@ class ComparePage extends PureComponent {
    * Fetch the data for the page if needed
    */
   fetchData(props) {
-    // const { dispatch } = props;
+    const { dispatch, facetLocationIds } = props;
+
+    // get location info if needed
+    if (facetLocationIds) {
+      facetLocationIds.forEach(facetLocationId => {
+        dispatch(LocationsActions.fetchInfoIfNeeded(facetLocationId));
+      });
+    }
   }
 
   /**

--- a/src/containers/LocationSearch/LocationSearch.jsx
+++ b/src/containers/LocationSearch/LocationSearch.jsx
@@ -6,15 +6,16 @@ import * as GlobalSearchSelectors from '../../redux/globalSearch/selectors';
 
 import { Search } from '../../components';
 
-function mapStateToProps(state) {
+function mapStateToProps(state, props) {
   return {
-    searchResults: GlobalSearchSelectors.getLocationSearchResults(state),
+    searchResults: GlobalSearchSelectors.getLocationSearchResults(state, props),
   };
 }
 
 class LocationSearch extends PureComponent {
   static propTypes = {
     dispatch: PropTypes.func,
+    exclude: PropTypes.array,
     onSuggestionSelected: PropTypes.func,
     router: PropTypes.object,
     searchResults: PropTypes.array,

--- a/src/containers/TransitIspSearch/TransitIspSearch.jsx
+++ b/src/containers/TransitIspSearch/TransitIspSearch.jsx
@@ -8,11 +8,11 @@ import { Search } from '../../components';
 
 function mapStateToProps(state, props) {
   return {
-    searchResults: GlobalSearchSelectors.getClientIspSearchResults(state, props),
+    searchResults: GlobalSearchSelectors.getTransitIspSearchResults(state, props),
   };
 }
 
-class ClientIspSearch extends PureComponent {
+class TransitIspSearch extends PureComponent {
   static propTypes = {
     dispatch: PropTypes.func,
     exclude: PropTypes.array,
@@ -33,7 +33,7 @@ class ClientIspSearch extends PureComponent {
    */
   onSearchQueryChange(query) {
     const { dispatch } = this.props;
-    dispatch(GlobalSearchActions.fetchClientIspSearchIfNeeded(query));
+    dispatch(GlobalSearchActions.fetchTransitIspSearchIfNeeded(query));
   }
 
   render() {
@@ -41,9 +41,9 @@ class ClientIspSearch extends PureComponent {
 
     return (
       <Search
-        className="ClientIspSearch"
-        defaultSectionName="Client ISPs"
-        placeholder="Search for a client ISP"
+        className="TransitIspSearch"
+        defaultSectionName="Transit ISPs"
+        placeholder="Search for a transit ISP"
         searchResults={searchResults}
         onSearchChange={this.onSearchQueryChange}
         onSuggestionSelected={onSuggestionSelected}
@@ -52,4 +52,4 @@ class ClientIspSearch extends PureComponent {
   }
 }
 
-export default connect(mapStateToProps)(withRouter(ClientIspSearch));
+export default connect(mapStateToProps)(withRouter(TransitIspSearch));

--- a/src/containers/index.js
+++ b/src/containers/index.js
@@ -5,3 +5,4 @@ export ComparePage from './ComparePage/ComparePage';
 export NotFoundPage from './NotFoundPage/NotFoundPage';
 
 export LocationSearch from './LocationSearch/LocationSearch';
+export ClientIspSearch from './ClientIspSearch/ClientIspSearch';

--- a/src/containers/index.js
+++ b/src/containers/index.js
@@ -6,3 +6,4 @@ export NotFoundPage from './NotFoundPage/NotFoundPage';
 
 export LocationSearch from './LocationSearch/LocationSearch';
 export ClientIspSearch from './ClientIspSearch/ClientIspSearch';
+export TransitIspSearch from './TransitIspSearch/TransitIspSearch';

--- a/src/redux/clientIsps/actions.js
+++ b/src/redux/clientIsps/actions.js
@@ -3,58 +3,9 @@
  */
 import createFetchAction from '../createFetchAction';
 
-export const FETCH_TIME_SERIES = 'clientIsps/FETCH_TIME_SERIES';
-export const FETCH_TIME_SERIES_SUCCESS = 'clientIsps/FETCH_TIME_SERIES_SUCCESS';
-export const FETCH_TIME_SERIES_FAIL = 'clientIsps/FETCH_TIME_SERIES_FAIL';
-
 /**
  * Action Creators
  */
-
-// ---------------------
-// Fetch Time Series
-// ---------------------
-export function shouldFetchTimeSeries(state, timeAggregation, clientIspId, options) {
-  const clientIspState = state.clientIsps[clientIspId];
-  if (!clientIspState) {
-    return true;
-  }
-  const { timeSeries } = clientIspState.time;
-
-  // if we don't have this time aggregation, we should fetch it
-  if (timeSeries.timeAggregation !== timeAggregation) {
-    return true;
-  }
-
-  if (options.startDate && !options.startDate.isSame(timeSeries.startDate, timeAggregation)) {
-    return true;
-  }
-
-  if (options.endDate && !options.endDate.isSame(timeSeries.endDate, timeAggregation)) {
-    return true;
-  }
-
-  // only fetch if it isn't fetching/already fetched
-  return !(timeSeries.isFetched || timeSeries.isFetching);
-}
-
-export function fetchTimeSeries(timeAggregation, clientIspId, options) {
-  return {
-    types: [FETCH_TIME_SERIES, FETCH_TIME_SERIES_SUCCESS, FETCH_TIME_SERIES_FAIL],
-    promise: (api) => api.getClientIspTimeSeries(timeAggregation, clientIspId, options),
-    clientIspId,
-    timeAggregation,
-  };
-}
-
-export function fetchTimeSeriesIfNeeded(timeAggregation, clientIspId, options) {
-  return (dispatch, getState) => {
-    if (shouldFetchTimeSeries(getState(), timeAggregation, clientIspId, options)) {
-      dispatch(fetchTimeSeries(timeAggregation, clientIspId, options));
-    }
-  };
-}
-
 
 // ---------------------
 // Fetch Client ISP Info

--- a/src/redux/clientIsps/actions.js
+++ b/src/redux/clientIsps/actions.js
@@ -1,6 +1,8 @@
 /**
  * Actions for clientIsps
  */
+import createFetchAction from '../createFetchAction';
+
 export const FETCH_TIME_SERIES = 'clientIsps/FETCH_TIME_SERIES';
 export const FETCH_TIME_SERIES_SUCCESS = 'clientIsps/FETCH_TIME_SERIES_SUCCESS';
 export const FETCH_TIME_SERIES_FAIL = 'clientIsps/FETCH_TIME_SERIES_FAIL';
@@ -49,6 +51,66 @@ export function fetchTimeSeriesIfNeeded(timeAggregation, clientIspId, options) {
   return (dispatch, getState) => {
     if (shouldFetchTimeSeries(getState(), timeAggregation, clientIspId, options)) {
       dispatch(fetchTimeSeries(timeAggregation, clientIspId, options));
+    }
+  };
+}
+
+
+// ---------------------
+// Fetch Client ISP Info
+// ---------------------
+const infoFetch = createFetchAction({
+  typePrefix: 'clientIsps/',
+  key: 'INFO',
+  args: ['clientIspId'],
+  shouldFetch(state, clientIspId) {
+    const clientIspState = state.clientIsps[clientIspId];
+    if (!clientIspState) {
+      return true;
+    }
+
+    const hasInfo = clientIspState.info.isFetched || clientIspState.info.isFetching;
+    return !hasInfo;
+  },
+  promise(clientIspId) {
+    return api => api.getClientIspInfo(clientIspId);
+  },
+});
+export const FETCH_INFO = infoFetch.types.fetch;
+export const FETCH_INFO_SUCCESS = infoFetch.types.success;
+export const FETCH_INFO_FAIL = infoFetch.types.fail;
+export const shouldFetchInfo = infoFetch.shouldFetch;
+export const fetchInfo = infoFetch.fetch;
+export const fetchInfoIfNeeded = infoFetch.fetchIfNeeded;
+
+/**
+ * When receiving partial client ISP info, save it to the store if it isn't already there.
+ * This is typically done when using a value from a search result that hasn't yet been
+ * populated in the client ISP store.
+ */
+export const SAVE_CLIENT_ISP_INFO = 'clientIsps/SAVE_CLIENT_ISP_INFO';
+export function shouldSaveClientIspInfo(state, clientIsp) {
+  const clientIspState = state.clientIsps[clientIsp.id];
+  if (!clientIspState) {
+    return true;
+  }
+
+  return !clientIspState.info.isFetched;
+}
+
+export function saveClientIspInfo(clientIspInfo) {
+  return {
+    type: SAVE_CLIENT_ISP_INFO,
+    clientIspId: clientIspInfo.id,
+    result: { meta: clientIspInfo },
+  };
+}
+
+export function saveClientIspInfoIfNeeded(clientIspInfo) {
+  return (dispatch, getState) => {
+    const state = getState();
+    if (shouldSaveClientIspInfo(state, clientIspInfo)) {
+      dispatch(saveClientIspInfo(clientIspInfo));
     }
   };
 }

--- a/src/redux/clientIsps/reducer.js
+++ b/src/redux/clientIsps/reducer.js
@@ -136,6 +136,9 @@ function clientIsps(state = initialState, action = {}) {
   const { clientIspId } = action;
   switch (action.type) {
     case Actions.SAVE_CLIENT_ISP_INFO:
+    case Actions.FETCH_INFO:
+    case Actions.FETCH_INFO_SUCCESS:
+    case Actions.FETCH_INFO_FAIL:
     case Actions.FETCH_TIME_SERIES:
     case Actions.FETCH_TIME_SERIES_SUCCESS:
     case Actions.FETCH_TIME_SERIES_FAIL:

--- a/src/redux/clientIsps/reducer.js
+++ b/src/redux/clientIsps/reducer.js
@@ -1,6 +1,7 @@
 /**
  * Reducer for clientIsps
  */
+import { combineReducers } from 'redux';
 import * as Actions from './actions';
 
 /**
@@ -28,6 +29,13 @@ const initialState = {
 };
 
 export const initialClientIspState = {
+  id: null,
+
+  info: {
+    isFetching: false,
+    isFetched: false,
+  },
+
   time: {
     timeSeries: {
       isFetching: false,
@@ -83,27 +91,51 @@ function time(state = initialClientIspState.time, action = {}) {
 }
 
 
-// reducer for each clientIsp
-function clientIsp(state = initialClientIspState, action = {}) {
-  const { clientIspId } = action;
+// reducer for client ISP info
+function info(state = initialClientIspState.info, action = {}) {
   switch (action.type) {
-    case Actions.FETCH_TIME_SERIES:
-    case Actions.FETCH_TIME_SERIES_SUCCESS:
-    case Actions.FETCH_TIME_SERIES_FAIL:
+    case Actions.FETCH_INFO:
       return {
-        ...state,
-        clientIspId,
-        time: time(state.time, action),
+        data: state.data,
+        isFetching: true,
+        isFetched: false,
+      };
+    case Actions.SAVE_CLIENT_ISP_INFO:
+    case Actions.FETCH_INFO_SUCCESS:
+      return {
+        // store the meta info directly
+        data: action.result.meta,
+        isFetching: false,
+        isFetched: true,
+      };
+    case Actions.FETCH_INFO_FAIL:
+      return {
+        isFetching: false,
+        isFetched: false,
+        error: action.error,
       };
     default:
       return state;
   }
 }
 
+
+// reducer to get the ID
+function id(state = initialClientIspState.id, action = {}) {
+  return action.clientIspId || state;
+}
+
+const clientIsp = combineReducers({
+  id,
+  info,
+  time,
+});
+
 // The root reducer
 function clientIsps(state = initialState, action = {}) {
   const { clientIspId } = action;
   switch (action.type) {
+    case Actions.SAVE_CLIENT_ISP_INFO:
     case Actions.FETCH_TIME_SERIES:
     case Actions.FETCH_TIME_SERIES_SUCCESS:
     case Actions.FETCH_TIME_SERIES_FAIL:

--- a/src/redux/comparePage/actions.js
+++ b/src/redux/comparePage/actions.js
@@ -11,9 +11,8 @@ export const changeFacetType = urlReplaceAction('facetType');
 export const changeStartDate = urlReplaceAction('startDate');
 export const changeEndDate = urlReplaceAction('endDate');
 
+// handle Facet locations
 const changeFacetLocationIds = urlReplaceAction('facetLocationIds');
-
-
 export function changeFacetLocations(newFacetLocations, urlConnectDispatch) {
   return () => {
     // ensure these locations are all saved in the location map
@@ -23,5 +22,20 @@ export function changeFacetLocations(newFacetLocations, urlConnectDispatch) {
 
     // update the IDs in the URL
     urlConnectDispatch(changeFacetLocationIds(newFacetLocations.map(d => d.id)));
+  };
+}
+
+// handle Filter client ISPs
+const changeFilterClientIspIds = urlReplaceAction('filterClientIspIds');
+export function changeFilterClientIsps(newFilterClientIsps, urlConnectDispatch) {
+  return () => {
+    // ensure these locations are all saved in the location map
+    newFilterClientIsps.forEach(clientIspInfo => {
+      // TODO: save info if needed
+      // urlConnectDispatch(saveClientIspInfoIfNeeded(clientIspInfo));
+    });
+
+    // update the IDs in the URL
+    urlConnectDispatch(changeFilterClientIspIds(newFilterClientIsps.map(d => d.id)));
   };
 }

--- a/src/redux/comparePage/actions.js
+++ b/src/redux/comparePage/actions.js
@@ -4,6 +4,7 @@
 import { urlReplaceAction } from '../../url/actions';
 import { saveLocationInfoIfNeeded } from '../locations/actions';
 import { saveClientIspInfoIfNeeded } from '../clientIsps/actions';
+import { saveTransitIspInfoIfNeeded } from '../transitIsps/actions';
 
 /** Actions that replace values in the URL */
 export const changeTimeAggregation = urlReplaceAction('timeAggregation');
@@ -37,5 +38,19 @@ export function changeFilterClientIsps(newFilterClientIsps, urlConnectDispatch) 
 
     // update the IDs in the URL
     urlConnectDispatch(changeFilterClientIspIds(newFilterClientIsps.map(d => d.id)));
+  };
+}
+
+// handle Filter transit ISPs
+const changeFilterTransitIspIds = urlReplaceAction('filterTransitIspIds');
+export function changeFilterTransitIsps(newFilterTransitIsps, urlConnectDispatch) {
+  return () => {
+    // ensure these locations are all saved in the location map
+    newFilterTransitIsps.forEach(transitIspInfo => {
+      urlConnectDispatch(saveTransitIspInfoIfNeeded(transitIspInfo));
+    });
+
+    // update the IDs in the URL
+    urlConnectDispatch(changeFilterTransitIspIds(newFilterTransitIsps.map(d => d.id)));
   };
 }

--- a/src/redux/comparePage/actions.js
+++ b/src/redux/comparePage/actions.js
@@ -3,6 +3,7 @@
  */
 import { urlReplaceAction } from '../../url/actions';
 import { saveLocationInfoIfNeeded } from '../locations/actions';
+import { saveClientIspInfoIfNeeded } from '../clientIsps/actions';
 
 /** Actions that replace values in the URL */
 export const changeTimeAggregation = urlReplaceAction('timeAggregation');
@@ -31,8 +32,7 @@ export function changeFilterClientIsps(newFilterClientIsps, urlConnectDispatch) 
   return () => {
     // ensure these locations are all saved in the location map
     newFilterClientIsps.forEach(clientIspInfo => {
-      // TODO: save info if needed
-      // urlConnectDispatch(saveClientIspInfoIfNeeded(clientIspInfo));
+      urlConnectDispatch(saveClientIspInfoIfNeeded(clientIspInfo));
     });
 
     // update the IDs in the URL

--- a/src/redux/comparePage/selectors.js
+++ b/src/redux/comparePage/selectors.js
@@ -1,5 +1,5 @@
 /**
- * Selectors for locationPage
+ * Selectors for comparePage
  */
 import { createSelector } from 'reselect';
 import { metrics, facetTypes } from '../../constants';
@@ -76,6 +76,18 @@ function getLocations(state) {
   return state.locations;
 }
 
+
+/**
+ * Input selector to get the selected filter client ISP IDs
+ */
+function getFilterClientIspIds(state, props) {
+  return props.filterClientIspIds;
+}
+
+function getClientIsps(state) {
+  return state.clientIsps;
+}
+
 // ----------------------
 // Selectors
 // ----------------------
@@ -99,7 +111,33 @@ export const getFacetLocations = createSelector(
 /**
  * Gets the location info for each facet location
  */
-export const getFacetLocationInfo = createSelector(
+export const getFacetLocationInfos = createSelector(
   getFacetLocations,
   (facetLocations) => facetLocations.map(facetLocation => facetLocation.info.data)
     .filter(d => d != null));
+
+
+/**
+ * Inflates facet location IDs into location values
+ */
+export const getFilterClientIsps = createSelector(
+  getClientIsps, getFilterClientIspIds,
+  (clientIsps, filterClientIspIds) => {
+    if (filterClientIspIds) {
+      const facetLocations = filterClientIspIds.map(id => clientIsps[id]).filter(d => d != null);
+      return facetLocations;
+    }
+
+    return [];
+  }
+);
+
+
+/**
+ * Gets the location info for each facet location
+ */
+export const getFilterClientIspInfos = createSelector(
+  getFilterClientIsps,
+  (filterClientIsps) => filterClientIsps.map(filterClientIsp => filterClientIsp.info.data)
+    .filter(d => d != null));
+

--- a/src/redux/comparePage/selectors.js
+++ b/src/redux/comparePage/selectors.js
@@ -88,6 +88,18 @@ function getClientIsps(state) {
   return state.clientIsps;
 }
 
+
+/**
+ * Input selector to get the selected filter transit ISP IDs
+ */
+function getFilterTransitIspIds(state, props) {
+  return props.filterTransitIspIds;
+}
+
+function getTransitIsps(state) {
+  return state.transitIsps;
+}
+
 // ----------------------
 // Selectors
 // ----------------------
@@ -118,7 +130,7 @@ export const getFacetLocationInfos = createSelector(
 
 
 /**
- * Inflates facet location IDs into location values
+ * Inflates facet client ISP IDs into client ISP values
  */
 export const getFilterClientIsps = createSelector(
   getClientIsps, getFilterClientIspIds,
@@ -134,10 +146,36 @@ export const getFilterClientIsps = createSelector(
 
 
 /**
- * Gets the location info for each facet location
+ * Gets the client ISP info for each facet client ISP
  */
 export const getFilterClientIspInfos = createSelector(
   getFilterClientIsps,
   (filterClientIsps) => filterClientIsps.map(filterClientIsp => filterClientIsp.info.data)
     .filter(d => d != null));
+
+
+/**
+ * Inflates facet transit ISP IDs into transit ISP values
+ */
+export const getFilterTransitIsps = createSelector(
+  getTransitIsps, getFilterTransitIspIds,
+  (transitIsps, filterTransitIspIds) => {
+    if (filterTransitIspIds) {
+      const facetLocations = filterTransitIspIds.map(id => transitIsps[id]).filter(d => d != null);
+      return facetLocations;
+    }
+
+    return [];
+  }
+);
+
+
+/**
+ * Gets the transit ISP info for each facet transit ISP
+ */
+export const getFilterTransitIspInfos = createSelector(
+  getFilterTransitIsps,
+  (filterTransitIsps) => filterTransitIsps.map(filterTransitIsp => filterTransitIsp.info.data)
+    .filter(d => d != null));
+
 

--- a/src/redux/globalSearch/actions.js
+++ b/src/redux/globalSearch/actions.js
@@ -1,36 +1,77 @@
 /**
  * Actions for search
  */
-export const FETCH_LOCATION_SEARCH = 'globalSearch/FETCH_LOCATION_SEARCH';
-export const FETCH_LOCATION_SEARCH_SUCCESS = 'globalSearch/FETCH_LOCATION_SEARCH_SUCCESS';
-export const FETCH_LOCATION_SEARCH_FAIL = 'globalSearch/FETCH_LOCATION_SEARCH_FAIL';
+import createFetchAction from '../createFetchAction';
 
 /**
  * Action Creators
  */
 
 // ---------------------
-// Fetch Global Search
+// Fetch Location Search
 // ---------------------
-function shouldFetchLocationSearch(state, searchQuery) {
-  if (searchQuery.length > 0) {
-    return true;
-  }
-  return false;
-}
-
-function fetchLocationSearch(searchQuery) {
-  return {
-    types: [FETCH_LOCATION_SEARCH, FETCH_LOCATION_SEARCH_SUCCESS, FETCH_LOCATION_SEARCH_FAIL],
-    promise: (api) => api.getLocationSearch(searchQuery),
-    searchQuery,
-  };
-}
-
-export function fetchLocationSearchIfNeeded(searchQuery) {
-  return (dispatch, getState) => {
-    if (shouldFetchLocationSearch(getState(), searchQuery)) {
-      dispatch(fetchLocationSearch(searchQuery));
+const locationSearchFetch = createFetchAction({
+  typePrefix: 'globalSearch/',
+  key: 'LOCATION_SEARCH',
+  args: ['searchQuery'],
+  shouldFetch(state, searchQuery) {
+    // ignore empty queries
+    if (searchQuery.length === 0) {
+      return false;
     }
-  };
-}
+
+    // is it a different query than what we had before?
+    const locationSearchState = state.globalSearch.locationSearch;
+    if (locationSearchState.query !== searchQuery) {
+      return true;
+    }
+
+    // query matches what is currently there.
+    return !(locationSearchState.isFetched || locationSearchState.isFetching);
+  },
+  promise(searchQuery) {
+    return api => api.getLocationSearch(searchQuery);
+  },
+});
+
+export const FETCH_LOCATION_SEARCH = locationSearchFetch.types.fetch;
+export const FETCH_LOCATION_SEARCH_SUCCESS = locationSearchFetch.types.success;
+export const FETCH_LOCATION_SEARCH_FAIL = locationSearchFetch.types.fail;
+export const shouldFetchLocationSearch = locationSearchFetch.shouldFetch;
+export const fetchLocationSearch = locationSearchFetch.fetch;
+export const fetchLocationSearchIfNeeded = locationSearchFetch.fetchIfNeeded;
+
+
+// ---------------------
+// Fetch Client ISP Search
+// ---------------------
+const clientIspSearchFetch = createFetchAction({
+  typePrefix: 'globalSearch/',
+  key: 'CLIENT_ISP_SEARCH',
+  args: ['searchQuery'],
+  shouldFetch(state, searchQuery) {
+    // ignore empty queries
+    if (searchQuery.length === 0) {
+      return false;
+    }
+
+    // is it a different query than what we had before?
+    const clientIspSearchState = state.globalSearch.clientIspSearch;
+    if (clientIspSearchState.query !== searchQuery) {
+      return true;
+    }
+
+    // query matches what is currently there.
+    return !(clientIspSearchState.isFetched || clientIspSearchState.isFetching);
+  },
+  promise(searchQuery) {
+    return api => api.getClientIspSearch(searchQuery);
+  },
+});
+
+export const FETCH_CLIENT_ISP_SEARCH = clientIspSearchFetch.types.fetch;
+export const FETCH_CLIENT_ISP_SEARCH_SUCCESS = clientIspSearchFetch.types.success;
+export const FETCH_CLIENT_ISP_SEARCH_FAIL = clientIspSearchFetch.types.fail;
+export const shouldFetchClientIspSearch = clientIspSearchFetch.shouldFetch;
+export const fetchClientIspSearch = clientIspSearchFetch.fetch;
+export const fetchClientIspSearchIfNeeded = clientIspSearchFetch.fetchIfNeeded;

--- a/src/redux/globalSearch/actions.js
+++ b/src/redux/globalSearch/actions.js
@@ -75,3 +75,38 @@ export const FETCH_CLIENT_ISP_SEARCH_FAIL = clientIspSearchFetch.types.fail;
 export const shouldFetchClientIspSearch = clientIspSearchFetch.shouldFetch;
 export const fetchClientIspSearch = clientIspSearchFetch.fetch;
 export const fetchClientIspSearchIfNeeded = clientIspSearchFetch.fetchIfNeeded;
+
+
+// ---------------------
+// Fetch Transit ISP Search
+// ---------------------
+const transitIspSearchFetch = createFetchAction({
+  typePrefix: 'globalSearch/',
+  key: 'TRANSIT_ISP_SEARCH',
+  args: ['searchQuery'],
+  shouldFetch(state, searchQuery) {
+    // ignore empty queries
+    if (searchQuery.length === 0) {
+      return false;
+    }
+
+    // is it a different query than what we had before?
+    const transitIspSearchState = state.globalSearch.transitIspSearch;
+    if (transitIspSearchState.query !== searchQuery) {
+      return true;
+    }
+
+    // query matches what is currently there.
+    return !(transitIspSearchState.isFetched || transitIspSearchState.isFetching);
+  },
+  promise(searchQuery) {
+    return api => api.getTransitIspSearch(searchQuery);
+  },
+});
+
+export const FETCH_TRANSIT_ISP_SEARCH = transitIspSearchFetch.types.fetch;
+export const FETCH_TRANSIT_ISP_SEARCH_SUCCESS = transitIspSearchFetch.types.success;
+export const FETCH_TRANSIT_ISP_SEARCH_FAIL = transitIspSearchFetch.types.fail;
+export const shouldFetchTransitIspSearch = transitIspSearchFetch.shouldFetch;
+export const fetchTransitIspSearch = transitIspSearchFetch.fetch;
+export const fetchTransitIspSearchIfNeeded = transitIspSearchFetch.fetchIfNeeded;

--- a/src/redux/globalSearch/reducer.js
+++ b/src/redux/globalSearch/reducer.js
@@ -11,9 +11,15 @@ const initialState = {
     isFetching: false,
     isFetched: false,
   },
+  clientIspSearch: {
+    data: [],
+    query: '',
+    isFetching: false,
+    isFetched: false,
+  },
 };
 
-// the location page reducer
+// the location search reducer
 function locationSearch(state = initialState.locationSearch, action = {}) {
   switch (action.type) {
     case Actions.FETCH_LOCATION_SEARCH:
@@ -51,7 +57,44 @@ function locationSearch(state = initialState.locationSearch, action = {}) {
   }
 }
 
+// the client ISP search reducer
+function clientIspSearch(state = initialState.clientIspSearch, action = {}) {
+  switch (action.type) {
+    case Actions.FETCH_CLIENT_ISP_SEARCH:
+      return {
+        // TODO: ideally this ensured that the data was filtered what query is.
+        data: state.data,
+        query: action.searchQuery,
+        isFetching: true,
+        isFetched: false,
+      };
+    case Actions.FETCH_CLIENT_ISP_SEARCH_SUCCESS:
+      // if the query has changed since, ignore this
+      if (state.query !== action.searchQuery) {
+        return state;
+      }
+      // query hasn't changed, so update results
+      return {
+        ...state,
+        data: action.result.results,
+        query: action.searchQuery,
+        isFetching: false,
+        isFetched: true,
+      };
+    case Actions.FETCH_CLIENT_ISP_SEARCH_FAIL:
+      return {
+        ...state,
+        isFetching: false,
+        isFetched: false,
+        error: action.error,
+      };
+    default:
+      return state;
+  }
+}
+
 // Export the reducer
 export default combineReducers({
   locationSearch,
+  clientIspSearch,
 });

--- a/src/redux/globalSearch/reducer.js
+++ b/src/redux/globalSearch/reducer.js
@@ -17,6 +17,12 @@ const initialState = {
     isFetching: false,
     isFetched: false,
   },
+  transitIspSearch: {
+    data: [],
+    query: '',
+    isFetching: false,
+    isFetched: false,
+  },
 };
 
 // the location search reducer
@@ -93,8 +99,46 @@ function clientIspSearch(state = initialState.clientIspSearch, action = {}) {
   }
 }
 
+
+// the transit ISP search reducer
+function transitIspSearch(state = initialState.transitIspSearch, action = {}) {
+  switch (action.type) {
+    case Actions.FETCH_TRANSIT_ISP_SEARCH:
+      return {
+        // TODO: ideally this ensured that the data was filtered what query is.
+        data: state.data,
+        query: action.searchQuery,
+        isFetching: true,
+        isFetched: false,
+      };
+    case Actions.FETCH_TRANSIT_ISP_SEARCH_SUCCESS:
+      // if the query has changed since, ignore this
+      if (state.query !== action.searchQuery) {
+        return state;
+      }
+      // query hasn't changed, so update results
+      return {
+        ...state,
+        data: action.result.results,
+        query: action.searchQuery,
+        isFetching: false,
+        isFetched: true,
+      };
+    case Actions.FETCH_TRANSIT_ISP_SEARCH_FAIL:
+      return {
+        ...state,
+        isFetching: false,
+        isFetched: false,
+        error: action.error,
+      };
+    default:
+      return state;
+  }
+}
+
 // Export the reducer
 export default combineReducers({
   locationSearch,
   clientIspSearch,
+  transitIspSearch,
 });

--- a/src/redux/globalSearch/selectors.js
+++ b/src/redux/globalSearch/selectors.js
@@ -7,10 +7,15 @@ export function getLocationSearch(state) {
   return state.globalSearch.locationSearch;
 }
 
-export function getLocationSearchResults(state) {
+export function getLocationSearchResults(state, props) {
   const locationSearch = getLocationSearch(state);
 
-  return locationSearch.data;
+  let results = locationSearch.data;
+  if (props.exclude) {
+    results = results.filter(location => !props.exclude.find(ex => ex.id === location.meta.id));
+  }
+
+  return results;
 }
 
 export function getLocationSearchQuery(state) {
@@ -25,10 +30,15 @@ export function getClientIspSearch(state) {
   return state.globalSearch.clientIspSearch;
 }
 
-export function getClientIspSearchResults(state) {
+export function getClientIspSearchResults(state, props) {
   const clientIspSearch = getClientIspSearch(state);
 
-  return clientIspSearch.data;
+  let results = clientIspSearch.data;
+  if (props.exclude) {
+    results = results.filter(clientIsp => !props.exclude.find(ex => ex.id === clientIsp.meta.id));
+  }
+
+  return results;
 }
 
 export function getClientIspSearchQuery(state) {

--- a/src/redux/globalSearch/selectors.js
+++ b/src/redux/globalSearch/selectors.js
@@ -2,6 +2,7 @@
  * Selectors for globalSearch
  */
 
+// Location Search
 export function getLocationSearch(state) {
   return state.globalSearch.locationSearch;
 }
@@ -16,4 +17,22 @@ export function getLocationSearchQuery(state) {
   const locationSearch = getLocationSearch(state);
 
   return locationSearch.query;
+}
+
+
+// Client ISP Search
+export function getClientIspSearch(state) {
+  return state.globalSearch.clientIspSearch;
+}
+
+export function getClientIspSearchResults(state) {
+  const clientIspSearch = getClientIspSearch(state);
+
+  return clientIspSearch.data;
+}
+
+export function getClientIspSearchQuery(state) {
+  const clientIspSearch = getClientIspSearch(state);
+
+  return clientIspSearch.query;
 }

--- a/src/redux/globalSearch/selectors.js
+++ b/src/redux/globalSearch/selectors.js
@@ -2,47 +2,48 @@
  * Selectors for globalSearch
  */
 
+// helper function for filtering search results
+function getSearchResults(results, exclude) {
+  if (exclude) {
+    results = results.filter(result => !exclude.find(ex => ex.id === result.meta.id));
+  }
+
+  return results;
+}
+
+// -----------------------
 // Location Search
+// -----------------------
 export function getLocationSearch(state) {
   return state.globalSearch.locationSearch;
 }
 
 export function getLocationSearchResults(state, props) {
   const locationSearch = getLocationSearch(state);
-
-  let results = locationSearch.data;
-  if (props.exclude) {
-    results = results.filter(location => !props.exclude.find(ex => ex.id === location.meta.id));
-  }
-
-  return results;
+  return getSearchResults(locationSearch.data, props.exclude);
 }
 
-export function getLocationSearchQuery(state) {
-  const locationSearch = getLocationSearch(state);
-
-  return locationSearch.query;
-}
-
-
+// -----------------------
 // Client ISP Search
+// -----------------------
 export function getClientIspSearch(state) {
   return state.globalSearch.clientIspSearch;
 }
 
 export function getClientIspSearchResults(state, props) {
   const clientIspSearch = getClientIspSearch(state);
-
-  let results = clientIspSearch.data;
-  if (props.exclude) {
-    results = results.filter(clientIsp => !props.exclude.find(ex => ex.id === clientIsp.meta.id));
-  }
-
-  return results;
+  return getSearchResults(clientIspSearch.data, props.exclude);
 }
 
-export function getClientIspSearchQuery(state) {
-  const clientIspSearch = getClientIspSearch(state);
 
-  return clientIspSearch.query;
+// -----------------------
+// Transit ISP Search
+// -----------------------
+export function getTransitIspSearch(state) {
+  return state.globalSearch.transitIspSearch;
+}
+
+export function getTransitIspSearchResults(state, props) {
+  const transitIspSearch = getTransitIspSearch(state);
+  return getSearchResults(transitIspSearch.data, props.exclude);
 }

--- a/src/redux/rootReducer.js
+++ b/src/redux/rootReducer.js
@@ -2,14 +2,16 @@ import { combineReducers } from 'redux';
 import { routerReducer } from 'react-router-redux';
 
 import { reducer as clientIsps } from './clientIsps';
+import { reducer as transitIsps } from './transitIsps';
 import { reducer as locations } from './locations';
 import { reducer as locationPage } from './locationPage';
 import { reducer as globalSearch } from './globalSearch';
 
 export default combineReducers({
   clientIsps,
+  globalSearch,
   locationPage,
   locations,
-  globalSearch,
   routing: routerReducer,
+  transitIsps,
 });

--- a/src/redux/transitIsps/actions.js
+++ b/src/redux/transitIsps/actions.js
@@ -1,0 +1,67 @@
+/**
+ * Actions for transitIsps
+ */
+import createFetchAction from '../createFetchAction';
+
+/**
+ * Action Creators
+ */
+
+// ---------------------
+// Fetch Transit ISP Info
+// ---------------------
+const infoFetch = createFetchAction({
+  typePrefix: 'transitIsps/',
+  key: 'INFO',
+  args: ['transitIspId'],
+  shouldFetch(state, transitIspId) {
+    const transitIspState = state.transitIsps[transitIspId];
+    if (!transitIspState) {
+      return true;
+    }
+
+    const hasInfo = transitIspState.info.isFetched || transitIspState.info.isFetching;
+    return !hasInfo;
+  },
+  promise(transitIspId) {
+    return api => api.getTransitIspInfo(transitIspId);
+  },
+});
+export const FETCH_INFO = infoFetch.types.fetch;
+export const FETCH_INFO_SUCCESS = infoFetch.types.success;
+export const FETCH_INFO_FAIL = infoFetch.types.fail;
+export const shouldFetchInfo = infoFetch.shouldFetch;
+export const fetchInfo = infoFetch.fetch;
+export const fetchInfoIfNeeded = infoFetch.fetchIfNeeded;
+
+/**
+ * When receiving partial transit ISP info, save it to the store if it isn't already there.
+ * This is typically done when using a value from a search result that hasn't yet been
+ * populated in the transit ISP store.
+ */
+export const SAVE_TRANSIT_ISP_INFO = 'transitIsps/SAVE_TRANSIT_ISP_INFO';
+export function shouldSaveTransitIspInfo(state, transitIsp) {
+  const transitIspState = state.transitIsps[transitIsp.id];
+  if (!transitIspState) {
+    return true;
+  }
+
+  return !transitIspState.info.isFetched;
+}
+
+export function saveTransitIspInfo(transitIspInfo) {
+  return {
+    type: SAVE_TRANSIT_ISP_INFO,
+    transitIspId: transitIspInfo.id,
+    result: { meta: transitIspInfo },
+  };
+}
+
+export function saveTransitIspInfoIfNeeded(transitIspInfo) {
+  return (dispatch, getState) => {
+    const state = getState();
+    if (shouldSaveTransitIspInfo(state, transitIspInfo)) {
+      dispatch(saveTransitIspInfo(transitIspInfo));
+    }
+  };
+}

--- a/src/redux/transitIsps/index.js
+++ b/src/redux/transitIsps/index.js
@@ -1,0 +1,3 @@
+export * as Actions from './actions';
+export reducer from './reducer';
+export * as Selectors from './selectors';

--- a/src/redux/transitIsps/reducer.js
+++ b/src/redux/transitIsps/reducer.js
@@ -1,5 +1,5 @@
 /**
- * Reducer for clientIsps
+ * Reducer for transitIsps
  */
 import { combineReducers } from 'redux';
 import * as Actions from './actions';
@@ -7,7 +7,7 @@ import * as Actions from './actions';
 const initialState = {
 };
 
-export const initialClientIspState = {
+export const initialTransitIspState = {
   id: null,
 
   info: {
@@ -16,8 +16,8 @@ export const initialClientIspState = {
   },
 };
 
-// reducer for client ISP info
-function info(state = initialClientIspState.info, action = {}) {
+// reducer for transit ISP info
+function info(state = initialTransitIspState.info, action = {}) {
   switch (action.type) {
     case Actions.FETCH_INFO:
       return {
@@ -25,7 +25,7 @@ function info(state = initialClientIspState.info, action = {}) {
         isFetching: true,
         isFetched: false,
       };
-    case Actions.SAVE_CLIENT_ISP_INFO:
+    case Actions.SAVE_TRANSIT_ISP_INFO:
     case Actions.FETCH_INFO_SUCCESS:
       return {
         // store the meta info directly
@@ -46,26 +46,26 @@ function info(state = initialClientIspState.info, action = {}) {
 
 
 // reducer to get the ID
-function id(state = initialClientIspState.id, action = {}) {
-  return action.clientIspId || state;
+function id(state = initialTransitIspState.id, action = {}) {
+  return action.transitIspId || state;
 }
 
-const clientIsp = combineReducers({
+const transitIsp = combineReducers({
   id,
   info,
 });
 
 // The root reducer
-function clientIsps(state = initialState, action = {}) {
-  const { clientIspId } = action;
+function transitIsps(state = initialState, action = {}) {
+  const { transitIspId } = action;
   switch (action.type) {
-    case Actions.SAVE_CLIENT_ISP_INFO:
+    case Actions.SAVE_TRANSIT_ISP_INFO:
     case Actions.FETCH_INFO:
     case Actions.FETCH_INFO_SUCCESS:
     case Actions.FETCH_INFO_FAIL:
       return {
         ...state,
-        [clientIspId]: clientIsp(state[clientIspId], action),
+        [transitIspId]: transitIsp(state[transitIspId], action),
       };
     default:
       return state;
@@ -74,4 +74,4 @@ function clientIsps(state = initialState, action = {}) {
 
 
 // Export the reducer
-export default clientIsps;
+export default transitIsps;

--- a/src/redux/transitIsps/selectors.js
+++ b/src/redux/transitIsps/selectors.js
@@ -1,5 +1,5 @@
 /**
- * Selectors for client ISPs
+ * Selectors for transit ISPs
  */
 
 // import { createSelector } from 'reselect';


### PR DESCRIPTION
Persists in the URL and it grabs info on load. Currently fakes getting proper client ISP and transit ISP info on load since we don't have the /info API endpoints for them yet.

![image](https://cloud.githubusercontent.com/assets/793847/18725633/1510e064-800f-11e6-9ef5-cd85bf0b6af1.png)
