### PR TITLE
Add in color and label support for compare tool

### DIFF
--- a/src/api/calls/clientIspTransitIsp.js
+++ b/src/api/calls/clientIspTransitIsp.js
@@ -4,6 +4,7 @@ import {
   transform,
   transformTimeSeries,
   transformHourly,
+  transformClientIspLabel,
   transformTransitIspLabel,
   transformFixedData,
 } from '../transforms';
@@ -35,7 +36,7 @@ export function getClientIspTransitIspTimeSeries(timeAggregation, clientIspId, t
   const params = getMetricsParams(timeAggregation, options);
 
   return get(`/clients/${clientIspId}/servers/${transitIspId}/metrics`, params)
-    .then(transform(transformTransitIspLabel, transformTimeSeries));
+    .then(transform(transformClientIspLabel, transformTransitIspLabel, transformTimeSeries));
 }
 
 
@@ -53,5 +54,5 @@ export function getClientIspTransitIspHourly(timeAggregation, clientIspId, trans
   const params = getMetricsParams(`${timeAggregation}_hour`, options);
 
   return get(`/clients/${clientIspId}/servers/${transitIspId}/metrics`, params)
-    .then(transform(transformTransitIspLabel, transformHourly));
+    .then(transform(transformClientIspLabel, transformTransitIspLabel, transformHourly));
 }

--- a/src/api/calls/locationClientIsp.js
+++ b/src/api/calls/locationClientIsp.js
@@ -5,6 +5,7 @@ import {
   transformTimeSeries,
   transformHourly,
   transformClientIspLabel,
+  transformLocationLabel,
   transformFixedData,
 } from '../transforms';
 
@@ -35,7 +36,7 @@ export function getLocationClientIspTimeSeries(timeAggregation, locationId, clie
   const params = getMetricsParams(timeAggregation, options);
 
   return get(`/locations/${locationId}/clients/${clientIspId}/metrics`, params)
-    .then(transform(transformClientIspLabel, transformTimeSeries));
+    .then(transform(transformLocationLabel, transformClientIspLabel, transformTimeSeries));
 }
 
 
@@ -53,5 +54,5 @@ export function getLocationClientIspHourly(timeAggregation, locationId, clientIs
   const params = getMetricsParams(`${timeAggregation}_hour`, options);
 
   return get(`/locations/${locationId}/clients/${clientIspId}/metrics`, params)
-    .then(transform(transformClientIspLabel, transformHourly));
+    .then(transform(transformLocationLabel, transformClientIspLabel, transformHourly));
 }

--- a/src/api/calls/locationClientIspTransitIsp.js
+++ b/src/api/calls/locationClientIspTransitIsp.js
@@ -4,7 +4,9 @@ import {
   transform,
   transformTimeSeries,
   transformHourly,
+  transformLocationLabel,
   transformClientIspLabel,
+  transformTransitIspLabel,
   transformFixedData,
 } from '../transforms';
 
@@ -37,7 +39,7 @@ export function getLocationClientIspTransitIspTimeSeries(timeAggregation, locati
   const params = getMetricsParams(timeAggregation, options);
 
   return get(`/locations/${locationId}/clients/${clientIspId}/servers/${transitIspId}/metrics`, params)
-    .then(transform(transformClientIspLabel, transformTimeSeries));
+    .then(transform(transformLocationLabel, transformClientIspLabel, transformTransitIspLabel, transformTimeSeries));
 }
 
 
@@ -56,5 +58,5 @@ export function getLocationClientIspTransitIspHourly(timeAggregation, locationId
   const params = getMetricsParams(`${timeAggregation}_hour`, options);
 
   return get(`/locations/${locationId}/clients/${clientIspId}/servers/${transitIspId}/metrics`, params)
-    .then(transform(transformClientIspLabel, transformHourly));
+    .then(transform(transformLocationLabel, transformClientIspLabel, transformTransitIspLabel, transformHourly));
 }

--- a/src/api/calls/locationTransitIsp.js
+++ b/src/api/calls/locationTransitIsp.js
@@ -5,6 +5,7 @@ import {
   transformTimeSeries,
   transformHourly,
   transformTransitIspLabel,
+  transformLocationLabel,
   transformFixedData,
 } from '../transforms';
 
@@ -35,7 +36,7 @@ export function getLocationTransitIspTimeSeries(timeAggregation, locationId, tra
   const params = getMetricsParams(timeAggregation, options);
 
   return get(`/locations/${locationId}/servers/${transitIspId}/metrics`, params)
-    .then(transform(transformTransitIspLabel, transformTimeSeries));
+    .then(transform(transformLocationLabel, transformTransitIspLabel, transformTimeSeries));
 }
 
 
@@ -53,5 +54,5 @@ export function getLocationTransitIspHourly(timeAggregation, locationId, transit
   const params = getMetricsParams(`${timeAggregation}_hour`, options);
 
   return get(`/locations/${locationId}/servers/${transitIspId}/metrics`, params)
-    .then(transform(transformTransitIspLabel, transformHourly));
+    .then(transform(transformLocationLabel, transformTransitIspLabel, transformHourly));
 }

--- a/src/api/transforms.js
+++ b/src/api/transforms.js
@@ -130,6 +130,23 @@ export function transformHourly(body) {
   return body;
 }
 
+function locationLabel(meta) {
+  let label = meta.client_city || meta.client_region || meta.client_country || meta.client_continent;
+
+  // Create a display name for locations.
+  if (meta.type === 'city') {
+    if (meta.client_country === 'United States') {
+      label += `, ${meta.client_region}`;
+    } else {
+      label += `, ${meta.client_country}`;
+    }
+  } else if (meta.type === 'region') {
+    label += `, ${meta.client_country}`;
+  }
+
+  return label;
+}
+
 /**
  * Transforms location meta to have label
  *
@@ -144,18 +161,8 @@ export function transformLocationLabel(body) {
     const { meta } = body;
 
     meta.shortLabel = meta.client_city || meta.client_region || meta.client_country || meta.client_continent;
-    meta.label = meta.shortLabel;
-
-    // Create a display name for locations.
-    if (meta.type === 'city') {
-      if (meta.client_country === 'United States') {
-        meta.label += `, ${meta.client_region}`;
-      } else {
-        meta.label += `, ${meta.client_country}`;
-      }
-    } else if (meta.type === 'region') {
-      meta.label += `, ${meta.client_country}`;
-    }
+    meta.label = locationLabel(meta);
+    meta.client_location_label = meta.label;
   }
 
   return body;
@@ -244,6 +251,9 @@ export function transformClientIspLabel(body) {
   if (body.meta) {
     const { meta } = body;
 
+    if (!meta.client_asn_name || !meta.client_asn_name.length) {
+      meta.client_asn_name = meta.client_asn_number;
+    }
     meta.label = meta.client_asn_name;
   }
 
@@ -408,7 +418,7 @@ export function transformMapMeta(body) {
 export function transformClientIspInfo(body) {
   // NOTE: modifying body directly means it modifies what is stored in the API cache
   if (body.meta) {
-    body.meta.label = body.meta.client_asn_name;
+    transformClientIspLabel(body);
   }
 
   return body;
@@ -425,7 +435,7 @@ export function transformClientIspInfo(body) {
 export function transformTransitIspInfo(body) {
   // NOTE: modifying body directly means it modifies what is stored in the API cache
   if (body.meta) {
-    body.meta.label = body.meta.server_asn_name;
+    transformTransitIspLabel(body);
   }
 
   return body;
@@ -445,6 +455,9 @@ export function transformTransitIspLabel(body) {
   if (body.meta) {
     const { meta } = body;
 
+    if (!meta.server_asn_name || !meta.server_asn_name.length) {
+      meta.server_asn_name = meta.server_asn_number;
+    }
     meta.label = meta.server_asn_name;
   }
 

--- a/src/components/CompareTimeSeriesCharts/CompareTimeSeriesCharts.jsx
+++ b/src/components/CompareTimeSeriesCharts/CompareTimeSeriesCharts.jsx
@@ -17,10 +17,12 @@ export default class CompareTimeSeriesCharts extends PureComponent {
     facetItemId: PropTypes.string,
     facetItemInfo: PropTypes.object,
     facetItemTimeSeries: PropTypes.object,
+    facetType: PropTypes.object,
     filter1Ids: PropTypes.array,
     filter1Infos: PropTypes.array,
     filter2Ids: PropTypes.array,
     filter2Infos: PropTypes.array,
+    filterTypes: PropTypes.array,
     highlightTimeSeriesDate: PropTypes.object,
     highlightTimeSeriesLine: PropTypes.object,
     onHighlightTimeSeriesDate: PropTypes.func,
@@ -28,7 +30,7 @@ export default class CompareTimeSeriesCharts extends PureComponent {
     viewMetric: PropTypes.object,
   }
 
-  renderTimeSeries(chartId, timeSeries) {
+  renderTimeSeries(chartId, timeSeries, lineDataType) {
     const {
       colors,
       highlightTimeSeriesDate,
@@ -52,6 +54,8 @@ export default class CompareTimeSeriesCharts extends PureComponent {
       <StatusWrapper status={status}>
         <LineChartWithCounts
           id={chartId}
+          idKey={lineDataType.idKey}
+          labelKey={lineDataType.labelKey}
           colors={colors}
           series={seriesData}
           onHighlightDate={onHighlightTimeSeriesDate}
@@ -78,6 +82,7 @@ export default class CompareTimeSeriesCharts extends PureComponent {
   renderNoFilters(facetItemInfo) {
     const {
       facetItemTimeSeries,
+      facetType,
     } = this.props;
 
     if (!facetItemTimeSeries) {
@@ -87,11 +92,11 @@ export default class CompareTimeSeriesCharts extends PureComponent {
     const chartId = `facet-time-series-${facetItemInfo.id}`;
     const timeSeries = facetItemTimeSeries.timeSeries.find(seriesData => seriesData.id === facetItemInfo.id);
 
-    return this.renderTimeSeries(chartId, timeSeries);
+    return this.renderTimeSeries(chartId, timeSeries, facetType);
   }
 
   // if one filter has items, show the lines for those filter items in the chart
-  renderSingleFilter(facetItemInfo) {
+  renderSingleFilter(facetItemInfo, filterType) {
     const {
       combinedTimeSeries,
     } = this.props;
@@ -103,7 +108,7 @@ export default class CompareTimeSeriesCharts extends PureComponent {
     const chartId = `facet-single-filtered-time-series-${facetItemInfo.id}`;
 
     const timeSeriesObject = combinedTimeSeries;
-    return this.renderTimeSeries(chartId, timeSeriesObject);
+    return this.renderTimeSeries(chartId, timeSeriesObject, filterType);
   }
 
   // if both filters have items, group by `breakdownBy` filter and have the other filter items have lines in those charts
@@ -111,6 +116,7 @@ export default class CompareTimeSeriesCharts extends PureComponent {
     const {
       combinedTimeSeries,
       breakdownBy,
+      filterTypes,
     } = this.props;
 
     if (!combinedTimeSeries) {
@@ -119,6 +125,7 @@ export default class CompareTimeSeriesCharts extends PureComponent {
 
     const baseChartId = `facet-double-filtered-time-series-${facetItemInfo.id}`;
     const breakdownInfos = breakdownBy === 'filter1' ? filter1Infos : filter2Infos;
+    const lineDataType = breakdownBy === 'filter1' ? filterTypes[1] : filterTypes[0];
 
     return (
       <div>
@@ -129,7 +136,7 @@ export default class CompareTimeSeriesCharts extends PureComponent {
           return (
             <div key={breakdownId}>
               <h5>{breakdownInfo.label}</h5>
-              {this.renderTimeSeries(chartId, timeSeriesObject)}
+              {this.renderTimeSeries(chartId, timeSeriesObject, lineDataType)}
             </div>
           );
         })}
@@ -138,7 +145,7 @@ export default class CompareTimeSeriesCharts extends PureComponent {
   }
 
   render() {
-    const { facetItemInfo, filter1Ids, filter1Infos, filter2Ids, filter2Infos } = this.props;
+    const { facetItemInfo, filter1Ids, filter1Infos, filter2Ids, filter2Infos, filterTypes } = this.props;
     // if filters are empty, show the facet item line in the chart
     // if one filter has items, show the lines for those filter items in the chart
     // if both filters have items, group by `breakdownBy` filter and have the other filter items have lines in those charts
@@ -150,11 +157,11 @@ export default class CompareTimeSeriesCharts extends PureComponent {
 
     // only one filter (client ISPs)
     } else if (filter1Ids.length && !filter2Ids.length) {
-      groupCharts = this.renderSingleFilter(facetItemInfo, filter1Infos);
+      groupCharts = this.renderSingleFilter(facetItemInfo, filterTypes[0]);
 
     // only one filter (transit ISPs)
     } else if (!filter1Ids.length && filter2Ids.length) {
-      groupCharts = this.renderSingleFilter(facetItemInfo, filter2Infos);
+      groupCharts = this.renderSingleFilter(facetItemInfo, filterTypes[1]);
 
     // else two filters
     } else {

--- a/src/components/LineChart/LineChart.jsx
+++ b/src/components/LineChart/LineChart.jsx
@@ -13,6 +13,8 @@ import './LineChart.scss';
  */
 function visProps(props) {
   const {
+    idKey,
+    labelKey,
     series,
     forceZeroMin,
     height,
@@ -39,7 +41,7 @@ function visProps(props) {
 
   // initialize a color scale unless one was provided
   if (series && !colors) {
-    colors = colorsFor(series, (d) => d.meta.id);
+    colors = colorsFor(series, (d) => d.meta[idKey]);
   }
 
   const padding = {
@@ -57,6 +59,8 @@ function visProps(props) {
     colors,
     formatter: yFormatter,
     width: plotAreaWidth,
+    idKey,
+    labelKey,
   });
 
   padding.top += legend.height;
@@ -104,7 +108,7 @@ function visProps(props) {
     .defined(d => d[yKey] != null)
     .accessData(d => d.results)
     .lineStyles({
-      stroke: (d) => colors[d.meta.id] || '#aaa',
+      stroke: (d) => colors[d.meta[idKey]] || '#aaa',
       'stroke-width': 1.5,
     });
 
@@ -168,7 +172,9 @@ class LineChart extends PureComponent {
     highlightDate: React.PropTypes.object,
     highlightLine: React.PropTypes.object,
     id: React.PropTypes.string,
+    idKey: React.PropTypes.string,
     inSvg: React.PropTypes.bool,
+    labelKey: React.PropTypes.string,
     legend: React.PropTypes.object,
     lineChunked: React.PropTypes.func,
     onHighlightDate: React.PropTypes.func,
@@ -191,6 +197,8 @@ class LineChart extends PureComponent {
 
   static defaultProps = {
     forceZeroMin: true,
+    idKey: 'id',
+    labelKey: 'label',
     xKey: 'x',
     yFormatter: d => d,
     yKey: 'y',
@@ -375,7 +383,7 @@ class LineChart extends PureComponent {
   }
 
   updateHighlightDate(highlightValues) {
-    const { highlightDate, xScale, plotAreaHeight, yScale, yKey, series, colors } = this.props;
+    const { highlightDate, xScale, plotAreaHeight, yScale, yKey, series, colors, idKey } = this.props;
 
     // render the x-axis marker for highlightDate
     if (highlightDate == null) {
@@ -405,15 +413,15 @@ class LineChart extends PureComponent {
         .attr('r', 3)
         .attr('cx', 0)
         .style('fill', (d, i) => {
-          if (series[i] && colors[series[i].meta.id]) {
-            return d3.color(colors[series[i].meta.id]).brighter(0.3);
+          if (series[i] && colors[series[i].meta[idKey]]) {
+            return d3.color(colors[series[i].meta[idKey]]).brighter(0.3);
           }
 
           return '#bbb';
         })
         .style('stroke', (d, i) => {
-          if (series[i] && colors[series[i].meta.id]) {
-            return colors[series[i].meta.id];
+          if (series[i] && colors[series[i].meta[idKey]]) {
+            return colors[series[i].meta[idKey]];
           }
 
           return '#aaa';

--- a/src/components/LineChart/LineChartWithCounts.jsx
+++ b/src/components/LineChart/LineChartWithCounts.jsx
@@ -49,7 +49,7 @@ function prepareData(props) {
  * Figure out what is needed for both charts
  */
 function visProps(props) {
-  const { width, xExtent, xKey } = props;
+  const { width, xExtent, xKey, idKey } = props;
   let { highlightLine, colors } = props;
 
   const preparedData = prepareData(props);
@@ -76,7 +76,7 @@ function visProps(props) {
 
   // initialize a color scale
   if (series && !colors) {
-    colors = colorsFor(series, (d) => d.meta.id);
+    colors = colorsFor(series, (d) => d.meta[idKey]);
   } else if (!colors) {
     colors = {};
   }
@@ -133,6 +133,7 @@ class LineChartWithCounts extends PureComponent {
     highlightDate: React.PropTypes.object,
     highlightLine: React.PropTypes.object,
     id: React.PropTypes.string,
+    idKey: React.PropTypes.string,
     numBins: React.PropTypes.number,
     onHighlightDate: React.PropTypes.func,
     onHighlightLine: React.PropTypes.func,
@@ -151,6 +152,8 @@ class LineChartWithCounts extends PureComponent {
 
   static defaultProps = {
     threshold: 30,
+    idKey: 'id',
+    labelKey: 'label',
   }
 
   /**
@@ -159,12 +162,12 @@ class LineChartWithCounts extends PureComponent {
    */
   render() {
     const { id, width, xKey, annotationSeries, series, highlightLine, highlightDate,
-      onHighlightDate, counts, padding, xScale, numBins, colors } = this.props;
+      onHighlightDate, counts, padding, xScale, numBins, colors, idKey } = this.props;
 
     const lineChartHeight = 350;
     const countHeight = 80;
     const height = lineChartHeight + countHeight;
-    const highlightColor = highlightLine ? colors[highlightLine.meta.id] : undefined;
+    const highlightColor = highlightLine ? colors[highlightLine.meta[idKey]] : undefined;
     const highlightCountData = highlightLine ? highlightLine.results : undefined;
 
     return (

--- a/src/constants.js
+++ b/src/constants.js
@@ -45,7 +45,22 @@ export const metrics = [
 ];
 
 export const facetTypes = [
-  { value: 'location', label: 'Location' },
-  { value: 'clientIsp', label: 'Client ISP' },
-  { value: 'transitIsp', label: 'Transit ISP' },
+  {
+    value: 'location',
+    label: 'Location',
+    idKey: 'client_location_key',
+    labelKey: 'client_location_label',
+  },
+  {
+    value: 'clientIsp',
+    label: 'Client ISP',
+    idKey: 'client_asn_number',
+    labelKey: 'client_asn_name',
+  },
+  {
+    value: 'transitIsp',
+    label: 'Transit ISP',
+    idKey: 'server_asn_number',
+    labelKey: 'server_asn_name',
+  },
 ];

--- a/src/containers/ComparePage/ComparePage.jsx
+++ b/src/containers/ComparePage/ComparePage.jsx
@@ -534,6 +534,7 @@ class ComparePage extends PureComponent {
       highlightTimeSeriesDate,
       highlightTimeSeriesLine,
       viewMetric,
+      colors,
     } = this.props;
 
     if (!seriesData || seriesData.length === 0) {
@@ -545,6 +546,7 @@ class ComparePage extends PureComponent {
         <LineChartWithCounts
           id={chartId}
           series={seriesData}
+          colors={colors}
           onHighlightDate={this.onHighlightTimeSeriesDate}
           highlightDate={highlightTimeSeriesDate}
           onHighlightLine={this.onHighlightTimeSeriesLine}
@@ -605,10 +607,12 @@ class ComparePage extends PureComponent {
       facetItemInfos,
       facetItemTimeSeries,
       facetItemHourly,
+      facetType,
       filter1Ids,
       filter1Infos,
       filter2Ids,
       filter2Infos,
+      filterTypes,
       highlightHourly,
       highlightTimeSeriesDate,
       highlightTimeSeriesLine,
@@ -639,10 +643,12 @@ class ComparePage extends PureComponent {
                 facetItemId={facetItemInfo.id}
                 facetItemInfo={facetItemInfo}
                 facetItemTimeSeries={facetItemTimeSeries}
+                facetType={facetType}
                 filter1Ids={filter1Ids}
                 filter1Infos={filter1Infos}
                 filter2Ids={filter2Ids}
                 filter2Infos={filter2Infos}
+                filterTypes={filterTypes}
                 highlightTimeSeriesDate={highlightTimeSeriesDate}
                 highlightTimeSeriesLine={highlightTimeSeriesLine}
                 onHighlightTimeSeriesDate={this.onHighlightTimeSeriesDate}
@@ -665,10 +671,12 @@ class ComparePage extends PureComponent {
                   facetItemId={facetItemInfo.id}
                   facetItemInfo={facetItemInfo}
                   facetItemHourly={facetItemHourly}
+                  facetType={facetType}
                   filter1Ids={filter1Ids}
                   filter1Infos={filter1Infos}
                   filter2Ids={filter2Ids}
                   filter2Infos={filter2Infos}
+                  filterTypes={filterTypes}
                   highlightHourly={highlightHourly}
                   onHighlightHourly={this.onHighlightHourly}
                   viewMetric={viewMetric}

--- a/src/d3-components/Legend/Legend.js
+++ b/src/d3-components/Legend/Legend.js
@@ -7,12 +7,24 @@ import './Legend.scss';
  * root container node.
  */
 export default class Legend {
-  constructor({ data = [], colors, formatter = d => d, width, onHoverLegendEntry }) {
+  constructor(options) {
+    const {
+      data = [],
+      colors,
+      formatter = d => d,
+      width,
+      onHoverLegendEntry,
+      labelKey = 'label',
+      idKey = 'id',
+    } = options;
+
     this.data = data;
     this.colors = colors;
     this.formatter = formatter;
     this.width = width;
     this.onHoverLegendEntry = onHoverLegendEntry;
+    this.labelKey = labelKey;
+    this.idKey = idKey;
 
     const entryMarginRight = 14;
     const minEntryWidth = 180;
@@ -47,6 +59,9 @@ export default class Legend {
    * @return {void}
    */
   render(container, values, onHoverLegendEntry = () => {}, highlightDatum) {
+    const idKey = this.idKey;
+    const labelKey = this.labelKey;
+
     let root = container.select('.Legend');
 
     if (root.empty()) {
@@ -57,7 +72,7 @@ export default class Legend {
     // when mousing between entries
     root.on('mouseleave', () => onHoverLegendEntry(null));
 
-    const binding = root.selectAll('.legend-entry').data(this.data, d => d.meta.id);
+    const binding = root.selectAll('.legend-entry').data(this.data, d => d.meta[idKey]);
     binding.exit().remove();
 
     const { entry: entryConfig, colorBox: colorBoxConfig } = this.config;
@@ -68,12 +83,14 @@ export default class Legend {
       .attr('class', 'legend-entry')
       .each(function legendEnter(d) {
         const entry = d3.select(this);
+        const datumId = d.meta[idKey];
+        const label = d.meta[labelKey];
 
         const entryId = String(Math.random()).replace(/\./, '');
         const clipId = `legend-clip-${entryId}`;
 
         // use the provided color or default to gray
-        const color = colors[d.meta.id] || '#aaa';
+        const color = colors[datumId] || '#aaa';
 
         // clip on the inner entry so the mouse listener can be outside of it.
         const innerEntry = entry.append('g').attr('clip-path', `url(#${clipId})`);
@@ -99,7 +116,7 @@ export default class Legend {
           .attr('class', 'legend-entry-label')
           .attr('x', colorBoxConfig.width + colorBoxConfig.margin)
           .attr('dy', 12)
-          .text(d.meta.label);
+          .text(label);
 
         // prepare the area where values are shown
         // this is the white bg rect to overlap the label text if necessary

--- a/src/redux/comparePage/selectors.js
+++ b/src/redux/comparePage/selectors.js
@@ -569,7 +569,11 @@ export const getCombinedHourly = createSelector(
 export const getColors = createSelector(
   getFacetItemIds, getFilter1Ids, getFilter2Ids,
   (facetItemIds, filterClientIspIds, filterTransitIspIds) => {
-    const combined = [].concat(facetItemIds, filterClientIspIds, filterTransitIspIds);
-    return colorsFor(combined);
+    const combined = [facetItemIds, filterClientIspIds, filterTransitIspIds]
+      .filter(d => d != null)
+      .reduce((combined, ids) => combined.concat(ids), []);
+
+    const colors = colorsFor(combined);
+    return colors;
   }
 );


### PR DESCRIPTION
Now charts are coloured properly and have proper labels in the legend by using the correct ID and label keys depending on the facet/filter types.