### PR TITLE
Add interactivity to scatterplot

### DIFF
--- a/src/assets/_chart.scss
+++ b/src/assets/_chart.scss
@@ -12,6 +12,7 @@
     fill: #666;
   }
 
+  .highlight-y,
   .highlight-x {
     font-size: 10px;
     fill: #333;

--- a/src/components/ScatterGroup/ScatterGroup.jsx
+++ b/src/components/ScatterGroup/ScatterGroup.jsx
@@ -15,7 +15,6 @@ import './ScatterGroup.scss';
  * @prop {Number} height The height of the charts
  * @prop {Number} width The width of the charts
  * @prop {Func} onChange Metric change callback
- * @prop {Func} onHover Point hover callback
  */
 export default class ScatterGroup extends PureComponent {
   static propTypes = {
@@ -24,7 +23,6 @@ export default class ScatterGroup extends PureComponent {
     height: PropTypes.number,
     id: React.PropTypes.string,
     onChange: PropTypes.func,
-    onHover: PropTypes.func,
     summary: PropTypes.object,
     width: PropTypes.number,
   }
@@ -40,7 +38,12 @@ export default class ScatterGroup extends PureComponent {
   constructor(props) {
     super(props);
 
+    this.state = {
+      highlightPointId: null,
+    };
+
     this.onMetricChange = this.onMetricChange.bind(this);
+    this.onHighlightPoint = this.onHighlightPoint.bind(this);
   }
 
   /**
@@ -57,12 +60,24 @@ export default class ScatterGroup extends PureComponent {
   }
 
   /**
+   * Callback when a point is highlighted
+   * @param {Object} highlightPoint the point to highlight
+   */
+  onHighlightPoint(highlightPointId) {
+    this.setState({
+      highlightPointId,
+    });
+  }
+
+  /**
    * Renders plot
    * @param {Object} field Name and id of group of metrics to show in chart
    * @param {Object} allData Data for the field from summary
    */
   renderPlot(field, allData) {
     const { compareMetrics, width, height } = this.props;
+    const { highlightPointId } = this.state;
+
     const data = allData && allData.clientIspsData;
     const xMetric = (compareMetrics && compareMetrics.x) || metrics[0];
     const yMetric = (compareMetrics && compareMetrics.y) || metrics[1];
@@ -77,11 +92,15 @@ export default class ScatterGroup extends PureComponent {
           data={data}
           width={width}
           height={height}
+          highlightPointId={highlightPointId}
+          onHighlightPoint={this.onHighlightPoint}
           xAxisLabel={xMetric.label}
           xAxisUnit={xMetric.unit}
+          xFormatter={xMetric.formatter}
           xKey={xKey}
           yAxisLabel={yMetric.label}
           yAxisUnit={yMetric.unit}
+          yFormatter={yMetric.formatter}
           yKey={yKey}
         />
       </Col>

--- a/src/components/ScatterPlot/ScatterPlot.jsx
+++ b/src/components/ScatterPlot/ScatterPlot.jsx
@@ -143,18 +143,12 @@ class ScatterPlot extends PureComponent {
    * Helper to find the highlight point based off the ID
    */
   getHighlightPoint() {
-    const { data, highlightPointId, xKey, yKey } = this.props;
+    const { data, highlightPointId } = this.props;
     if (!data || !data.length || highlightPointId == null) {
       return null;
     }
 
     const highlightPoint = data.find(d => d.id === highlightPointId);
-
-    // TODO: temporarily check for xKey and yKey until bug is fixed.
-    if (!highlightPoint || highlightPoint[xKey] == null || highlightPoint[yKey] == null) {
-      return null;
-    }
-
     return highlightPoint;
   }
 
@@ -224,7 +218,7 @@ class ScatterPlot extends PureComponent {
       .attr('text-anchor', 'end');
     highlightY.append('line')
       .attr('transform', 'translate(10 0)')
-      .attr('x1', 0)
+      .attr('x1', 0);
 
     this.update();
   }
@@ -318,13 +312,12 @@ class ScatterPlot extends PureComponent {
       .on('mouseenter', d => this.onHoverPoint(d))
       .on('mouseleave', () => this.onHoverPoint(null));
 
-    // TODO: the values inside our summary data don't all get populated at once?
     binding.merge(entering)
-      .attr('cx', (d) => (d[xKey] ? xScale(d[xKey]) : -100))
-      .attr('cy', (d) => (d[yKey] ? yScale(d[yKey]) : -100))
+      .attr('cx', (d) => xScale(d[xKey]))
+      .attr('cy', (d) => yScale(d[yKey]))
       .attr('r', pointRadius)
-      .attr('stroke', (d) => (d.id ? colors[d.id] : '#fff'))
-      .attr('fill', (d) => (d.id ? d3.color(colors[d.id]).brighter(0.3) : '#fff'));
+      .attr('stroke', (d) => colors[d.id])
+      .attr('fill', (d) => d3.color(colors[d.id]).brighter(0.3));
   }
 
   /**

--- a/src/components/ScatterPlot/ScatterPlot.jsx
+++ b/src/components/ScatterPlot/ScatterPlot.jsx
@@ -189,8 +189,9 @@ class ScatterPlot extends PureComponent {
 
     // set up highlight
     this.highlight = this.g.append('g')
-      .attr('transform', 'translate(0 -5)')
-      .attr('class', 'highlight');
+      .attr('class', 'highlight')
+      .attr('transform', 'translate(0 -5)');
+
     this.highlight.append('text')
       .attr('class', 'highlight-label');
     const axisHighlight = this.highlight.append('g')
@@ -207,6 +208,8 @@ class ScatterPlot extends PureComponent {
     highlightX.append('text')
       .attr('dy', 15)
       .attr('text-anchor', 'middle');
+    highlightX.append('line')
+      .attr('y1', 0);
 
     const highlightY = axisHighlight.append('g').attr('class', 'highlight-y');
     // add in a rect to fill out the area beneath the hovered value in Y axis
@@ -219,6 +222,9 @@ class ScatterPlot extends PureComponent {
     highlightY.append('text')
       .attr('dy', 4)
       .attr('text-anchor', 'end');
+    highlightY.append('line')
+      .attr('transform', 'translate(10 0)')
+      .attr('x1', 0)
 
     this.update();
   }
@@ -265,12 +271,17 @@ class ScatterPlot extends PureComponent {
     const yValue = highlightPoint[yKey];
 
     // show the value in the x axis
+    const xAxisY = yScale.range()[0] + 4;
     const highlightX = this.highlight.select('.highlight-x')
-      .attr('transform', `translate(${xScale(xValue)} ${yScale.range()[0] + 4})`);
+      .attr('transform', `translate(${xScale(xValue)} ${xAxisY})`);
 
     highlightX.select('text')
       .style('fill', color)
       .text(xFormatter(xValue));
+    highlightX.select('line')
+      .attr('y2', -(xAxisY - yScale(yValue)))
+      .style('stroke', color);
+
 
     // show the value in the y axis
     const highlightY = this.highlight.select('.highlight-y')
@@ -278,6 +289,9 @@ class ScatterPlot extends PureComponent {
     highlightY.select('text')
       .style('fill', color)
       .text(yFormatter(yValue));
+    highlightY.select('line')
+      .attr('x2', xScale(xValue))
+      .style('stroke', color);
   }
 
   /**

--- a/src/components/ScatterPlot/ScatterPlot.jsx
+++ b/src/components/ScatterPlot/ScatterPlot.jsx
@@ -48,14 +48,16 @@ function visProps(props) {
     xDomain[0] = 0;
   }
 
+  const domainPaddingFactor = 1.15;
+
   const xScale = d3.scaleLinear().range([0, plotAreaWidth]).clamp(true);
   if (xDomain) {
-    xScale.domain(xDomain);
+    xScale.domain([xDomain[0], xDomain[1] * domainPaddingFactor]);
   }
 
   const yScale = d3.scaleLinear().range([plotAreaHeight, 0]).clamp(true);
   if (yDomain) {
-    yScale.domain(yDomain);
+    yScale.domain([yDomain[0], yDomain[1] * domainPaddingFactor]);
   }
 
   return {
@@ -90,6 +92,7 @@ class ScatterPlot extends PureComponent {
     padding: PropTypes.object,
     plotAreaHeight: PropTypes.number,
     plotAreaWidth: PropTypes.number,
+    pointRadius: PropTypes.number,
     width: PropTypes.number,
     xAxisLabel: React.PropTypes.string,
     xAxisUnit: React.PropTypes.string,
@@ -111,6 +114,7 @@ class ScatterPlot extends PureComponent {
     xKey: 'x',
     width: 200,
     height: 200,
+    pointRadius: 6,
     xFormatter: d => d,
     yFormatter: d => d,
   }
@@ -179,6 +183,7 @@ class ScatterPlot extends PureComponent {
       data,
       padding,
       colors,
+      pointRadius,
       xKey,
       xScale,
       yKey,
@@ -196,8 +201,9 @@ class ScatterPlot extends PureComponent {
     binding.merge(entering)
       .attr('cx', (d) => (d[xKey] ? xScale(d[xKey]) : -100))
       .attr('cy', (d) => (d[yKey] ? yScale(d[yKey]) : -100))
-      .attr('r', 8)
-      .attr('fill', (d) => (d.id ? colors[d.id] : '#fff'));
+      .attr('r', pointRadius)
+      .attr('stroke', (d) => (d.id ? colors[d.id] : '#fff'))
+      .attr('fill', (d) => (d.id ? d3.color(colors[d.id]).brighter(0.3) : '#fff'));
   }
 
   /**

--- a/src/components/ScatterPlot/ScatterPlot.scss
+++ b/src/components/ScatterPlot/ScatterPlot.scss
@@ -1,0 +1,6 @@
+.ScatterPlot {
+  .highlight-label {
+    font-size: 12px;
+    font-weight: 500;
+  }
+}

--- a/src/components/ScatterPlot/ScatterPlot.scss
+++ b/src/components/ScatterPlot/ScatterPlot.scss
@@ -3,4 +3,9 @@
     font-size: 12px;
     font-weight: 500;
   }
+
+  .highlight line {
+    stroke-width: 1px;
+    stroke: #aaa;
+  }
 }

--- a/src/redux/locationPage/selectors.js
+++ b/src/redux/locationPage/selectors.js
@@ -220,15 +220,18 @@ export const getSummaryData = createSelector(
 
       // add in the results for client ISPs here
       const clientIspsData = selectedClientIsps.map(clientIsp => {
-        const ispFixed = clientIsp.fixed.data || {};
-        const ispInfo = clientIsp.info.data || {};
+        const ispFixed = clientIsp.fixed.data;
+        const ispInfo = clientIsp.info.data;
+        if (!ispInfo || !ispFixed) {
+          return null;
+        }
 
         return {
           ...ispFixed[key],
           label: ispInfo.client_asn_name,
           id: ispInfo.client_asn_number,
         };
-      });
+      }).filter(d => d != null);
 
       grouped[key] = { locationData, clientIspsData };
 


### PR DESCRIPTION
- Adds interactivity when hovering over points in scatterplot
- Adjust styling of scatterplot circles, trims top margin
- Fixes bug where summary data would provide empty objects for ISPs

![a_scatterplot](https://cloud.githubusercontent.com/assets/793847/19087684/f31690bc-8a40-11e6-81e5-9c74473f4b4e.gif)
