### PR TITLE
Add generated download links to data page

### DIFF
--- a/src/api/getMetricsParams.js
+++ b/src/api/getMetricsParams.js
@@ -23,6 +23,12 @@ export default function getMetricsParams(timeAggregation, options) {
   if (options.endDate) {
     params.enddate = options.endDate.format(dateFormat);
   }
+  if (options.dataFormat) {
+    params.format = options.dataFormat;
+  }
+  if (options.download) {
+    params.download = 1;
+  }
 
   params.timebin = timeAggregation;
 

--- a/src/api/getMetricsUrl.js
+++ b/src/api/getMetricsUrl.js
@@ -1,0 +1,34 @@
+import { apiRoot } from '../config';
+import getMetricsParams from './getMetricsParams';
+
+function queryParamsToString(params) {
+  const parts = Object.keys(params).map(key => `${key}=${params[key]}`).join('&');
+  return parts.length ? `?${parts}` : '';
+}
+
+/**
+ * Helper function to create a URL for API metrics endpoints
+ */
+export default function getMetricsUrl(urlParts, relative = true) {
+  const {
+    locationId,
+    clientIspId,
+    transitIspId,
+  } = urlParts;
+
+  const parts = [];
+  if (locationId != null) {
+    parts.push(`locations/${locationId}`);
+  }
+  if (clientIspId != null) {
+    parts.push(`clients/${clientIspId}`);
+  }
+  if (transitIspId != null) {
+    parts.push(`servers/${transitIspId}`);
+  }
+
+  const urlRoot = `${relative ? '/' : `${apiRoot}/`}${parts.join('/')}/metrics`;
+  const metricsParams = getMetricsParams(urlParts.timeAggregation, urlParts);
+
+  return `${urlRoot}${queryParamsToString(metricsParams)}`;
+}

--- a/src/components/ApiDownloadLink/ApiDownloadLink.jsx
+++ b/src/components/ApiDownloadLink/ApiDownloadLink.jsx
@@ -1,0 +1,55 @@
+import React, { PureComponent, PropTypes } from 'react';
+import { apiRoot } from '../../config';
+
+/**
+ * Component to create a link to an API download endpoint based on the passed
+ * in props.
+ */
+export default class ApiDownloadLink extends PureComponent {
+  static propTypes = {
+    clientIspId: PropTypes.string,
+    clientIspLabel: PropTypes.string,
+    locationId: PropTypes.string,
+    locationLabel: PropTypes.string,
+    transitIspId: PropTypes.string,
+    transitIspLabel: PropTypes.string,
+  }
+
+  getLabel() {
+    const {
+      clientIspId,
+      clientIspLabel,
+      locationId,
+      locationLabel,
+      transitIspId,
+      transitIspLabel,
+    } = this.props;
+
+    const parts = [];
+
+    if (locationId) {
+      parts.push(locationLabel || locationId);
+    }
+    if (clientIspId) {
+      parts.push(clientIspLabel || clientIspId);
+    }
+    if (transitIspId) {
+      parts.push(transitIspLabel || transitIspId);
+    }
+
+
+    return parts.join(' --- ');
+  }
+
+  getUrl() {
+    return apiRoot;
+  }
+
+  render() {
+    return (
+      <a href={this.getUrl()}>
+        {this.getLabel()}
+      </a>
+    );
+  }
+}

--- a/src/components/ApiDownloadLink/ApiDownloadLink.jsx
+++ b/src/components/ApiDownloadLink/ApiDownloadLink.jsx
@@ -1,5 +1,8 @@
 import React, { PureComponent, PropTypes } from 'react';
-import { apiRoot } from '../../config';
+import momentPropTypes from 'react-moment-proptypes';
+
+import { stringToKey } from '../../utils/format';
+import getMetricsUrl from '../../api/getMetricsUrl';
 
 /**
  * Component to create a link to an API download endpoint based on the passed
@@ -9,13 +12,53 @@ export default class ApiDownloadLink extends PureComponent {
   static propTypes = {
     clientIspId: PropTypes.string,
     clientIspLabel: PropTypes.string,
+    dataFormat: PropTypes.string,
+    endDate: momentPropTypes.momentObj,
     locationId: PropTypes.string,
     locationLabel: PropTypes.string,
+    separator: PropTypes.string,
+    startDate: momentPropTypes.momentObj,
+    timeAggregation: PropTypes.string,
     transitIspId: PropTypes.string,
     transitIspLabel: PropTypes.string,
   }
 
+  static defaultProps = {
+    separator: ' --- ',
+  }
+
   getLabel() {
+    const {
+      clientIspId,
+      clientIspLabel,
+      locationId,
+      locationLabel,
+      separator,
+      transitIspId,
+      transitIspLabel,
+    } = this.props;
+
+    const parts = [];
+
+    if (locationId) {
+      parts.push(locationLabel || locationId);
+    }
+    if (clientIspId) {
+      parts.push(clientIspLabel || clientIspId);
+    }
+    if (transitIspId) {
+      parts.push(transitIspLabel || transitIspId);
+    }
+
+
+    return parts.join(separator);
+  }
+
+  getUrl() {
+    return getMetricsUrl(Object.assign({ download: true }, this.props), false);
+  }
+
+  getFilename() {
     const {
       clientIspId,
       clientIspLabel,
@@ -37,17 +80,12 @@ export default class ApiDownloadLink extends PureComponent {
       parts.push(transitIspLabel || transitIspId);
     }
 
-
-    return parts.join(' --- ');
-  }
-
-  getUrl() {
-    return apiRoot;
+    return parts.map(stringToKey).join('_');
   }
 
   render() {
     return (
-      <a href={this.getUrl()}>
+      <a download={this.getFilename()} href={this.getUrl()}>
         {this.getLabel()}
       </a>
     );

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -34,3 +34,4 @@ export CompareInputPanel from './CompareInputPanel/CompareInputPanel';
 export CompareTimeSeriesCharts from './CompareTimeSeriesCharts/CompareTimeSeriesCharts';
 export CompareHourCharts from './CompareHourCharts/CompareHourCharts';
 export FilterSuggestions from './FilterSuggestions/FilterSuggestions';
+export ApiDownloadLink from './ApiDownloadLink/ApiDownloadLink';

--- a/src/containers/DataPage/DataPage.jsx
+++ b/src/containers/DataPage/DataPage.jsx
@@ -452,7 +452,6 @@ class DataPage extends PureComponent {
   renderDownloadLinks() {
     // build up all combinations based on facetTypes
     const combinations = this.getDownloadCombinations();
-    console.log('got combinations', combinations);
 
     return (
       <div className="section download-plan">
@@ -460,18 +459,22 @@ class DataPage extends PureComponent {
           <h4>Download Links</h4>
         </header>
         <Row>
-          {combinations.map(combination => {
-            const { label, entries } = combination;
+          {combinations.length ?
+            combinations.map(combination => {
+              const { label, entries } = combination;
 
-            return (
-              <Col md={12} key={label}>
-                <h5>{label}</h5>
-                <ul className="list-unstyled">
-                  {entries.map((entry, i) => <li key={i}><ApiDownloadLink {...entry} /></li>)}
-                </ul>
-              </Col>
-            );
-          })}
+              return (
+                <Col md={12} key={label}>
+                  <h5>{label}</h5>
+                  <ul className="list-unstyled">
+                    {entries.map((entry, i) => <li key={i}><ApiDownloadLink {...entry} /></li>)}
+                  </ul>
+                </Col>
+              );
+            }) :
+            <Col md={12}>
+              <p>Please select at least one feature to generate the links to download data.</p>
+            </Col>}
         </Row>
       </div>
     );

--- a/src/containers/DataPage/DataPage.jsx
+++ b/src/containers/DataPage/DataPage.jsx
@@ -450,6 +450,8 @@ class DataPage extends PureComponent {
 
 
   renderDownloadLinks() {
+    const { timeAggregation, startDate, endDate, dataFormat } = this.props;
+
     // build up all combinations based on facetTypes
     const combinations = this.getDownloadCombinations();
 
@@ -467,7 +469,16 @@ class DataPage extends PureComponent {
                 <Col md={12} key={label}>
                   <h5>{label}</h5>
                   <ul className="list-unstyled">
-                    {entries.map((entry, i) => <li key={i}><ApiDownloadLink {...entry} /></li>)}
+                    {entries.map((entry, i) =>
+                      <li key={i}>
+                        <ApiDownloadLink
+                          {...entry}
+                          timeAggregation={timeAggregation}
+                          startDate={startDate}
+                          endDate={endDate}
+                          dataFormat={dataFormat}
+                        />
+                      </li>)}
                   </ul>
                 </Col>
               );

--- a/src/containers/DataPage/DataPage.scss
+++ b/src/containers/DataPage/DataPage.scss
@@ -14,4 +14,8 @@
   .download-btn {
     margin: 40px 0;
   }
+
+  .FilterSuggestions {
+    margin-bottom: 20px;
+  }
 }

--- a/src/utils/facetTypeCombinations.js
+++ b/src/utils/facetTypeCombinations.js
@@ -1,0 +1,35 @@
+import { facetTypes } from '../constants';
+
+/**
+ * Helper for doing recursive combining of the facet types
+ */
+function getFacetTypeCombinationsHelper(types, combined, prefix = []) {
+  if (!types.length) {
+    return combined;
+  }
+
+  const rootType = types[0];
+  const remainingTypes = types.slice(1);
+  const newPrefix = [...prefix, rootType.value];
+  combined.push(newPrefix);
+  for (let i = 0; i < remainingTypes.length; i += 1) {
+    combined = getFacetTypeCombinationsHelper(remainingTypes.slice(i), combined, newPrefix);
+  }
+
+  return combined;
+}
+
+/**
+ * Gets the combination of all facet types as an array of arrays.
+ */
+function getFacetTypeCombinations() {
+  const totalCombined = [];
+  for (let i = 0; i < facetTypes.length; i += 1) {
+    getFacetTypeCombinationsHelper(facetTypes.slice(i), totalCombined);
+  }
+
+  return totalCombined;
+}
+
+// return the singleton result
+export default getFacetTypeCombinations();


### PR DESCRIPTION
Decided that the easiest way to provide access to the variety of API calls that match the inputs is to list them as links. Would be nice to have a "download all" button, but that's a nice-to-have and would require some work on the API end first.

- Specify format via `format=csv` or `format=json` in the URL. The API needs to be updated to support this.
- Specify download via `download=1` -- this is currently not necessary on the front end, but will hopefully allow the API to send the response with a reasonable filename instead of metrics.json. 

![image](https://cloud.githubusercontent.com/assets/793847/19162003/1898ca10-8bc4-11e6-9e8d-141ae6dedb75.png)
