### PR TITLE
Chart data JSON and CSV export 

### DIFF
--- a/src/components/ChartExportControls/ChartExportControls.jsx
+++ b/src/components/ChartExportControls/ChartExportControls.jsx
@@ -1,4 +1,5 @@
 import React, { PureComponent, PropTypes } from 'react';
+import classNames from 'classnames';
 import { saveSvg, saveSvgAsPng } from 'save-svg-as-png';
 import { createCsv, download } from '../../utils/exports';
 
@@ -13,6 +14,7 @@ import './ChartExportControls.scss';
 export default class ChartExportControls extends PureComponent {
   static propTypes = {
     chartId: PropTypes.string.isRequired,
+    className: PropTypes.string,
     data: PropTypes.any,
     filename: PropTypes.string,
     prepareForCsv: PropTypes.func,
@@ -65,7 +67,7 @@ export default class ChartExportControls extends PureComponent {
 
   render() {
     return (
-      <div className="chart-export-controls">
+      <div className={classNames('chart-export-controls', this.props.className)}>
         <ul className="list-inline">
           {this.outputs.map(output => (
             <li key={output.label}>

--- a/src/components/ChartExportControls/ChartExportControls.jsx
+++ b/src/components/ChartExportControls/ChartExportControls.jsx
@@ -6,12 +6,20 @@ import './ChartExportControls.scss';
 
 /**
  * A component that exports charts in a variety of ways
+ *
+ * @prop {Function} prepareForCsv if provided, data is transformed by this into a flat array of
+ *   objects before being used to create a CSV file
  */
 export default class ChartExportControls extends PureComponent {
   static propTypes = {
     chartId: PropTypes.string.isRequired,
     data: PropTypes.any,
     filename: PropTypes.string,
+    prepareForCsv: PropTypes.func,
+  }
+
+  static defaultProps = {
+    prepareForCsv: d => d,
   }
 
   constructor(props) {
@@ -50,8 +58,8 @@ export default class ChartExportControls extends PureComponent {
   }
 
   onSaveCsv() {
-    const { data, filename } = this.props;
-    const csvDataString = createCsv(data);
+    const { data, filename, prepareForCsv } = this.props;
+    const csvDataString = createCsv(prepareForCsv(data));
     download(csvDataString, 'application/csv', `${filename}.csv`);
   }
 

--- a/src/components/ChartExportControls/ChartExportControls.scss
+++ b/src/components/ChartExportControls/ChartExportControls.scss
@@ -2,6 +2,17 @@
 
 .chart-export-controls {
   float: right;
+
+  // optimize spacing to account for margin right in chart and the count bar
+  &.for-hour-chart {
+    margin-right: 35px;
+  }
+
+  // optimize spacing to account for margin right in chart and the count bar
+  &.for-line-chart {
+    margin-right: 25px;
+  }
+
   li {
     margin-right: 0;
     padding: 0 2px;

--- a/src/components/CompareHourCharts/CompareHourCharts.jsx
+++ b/src/components/CompareHourCharts/CompareHourCharts.jsx
@@ -2,6 +2,7 @@ import React, { PureComponent, PropTypes } from 'react';
 import Row from 'react-bootstrap/lib/Row';
 import Col from 'react-bootstrap/lib/Col';
 import AutoWidth from 'react-auto-width';
+import { mergeMetaIntoResults } from '../../utils/exports';
 
 import {
   ChartExportControls,
@@ -68,8 +69,10 @@ export default class CompareHourCharts extends PureComponent {
           />
         </AutoWidth>
         <ChartExportControls
+          className="for-hour-chart"
           chartId={chartId}
-          data={hourlyData.results}
+          data={hourlyData}
+          prepareForCsv={mergeMetaIntoResults}
           filename={`compare_hourly_${viewMetric.value}_${chartId}`}
         />
       </StatusWrapper>

--- a/src/components/CompareTimeSeriesCharts/CompareTimeSeriesCharts.jsx
+++ b/src/components/CompareTimeSeriesCharts/CompareTimeSeriesCharts.jsx
@@ -1,6 +1,6 @@
 import React, { PureComponent, PropTypes } from 'react';
 import AutoWidth from 'react-auto-width';
-import { prepareMetricsLineChartForCsv } from '../../utils/exports';
+import { multiMergeMetaIntoResults } from '../../utils/exports';
 
 import {
   ChartExportControls,
@@ -75,8 +75,8 @@ export default class CompareTimeSeriesCharts extends PureComponent {
         <ChartExportControls
           className="for-line-chart"
           chartId={chartId}
-          data={[seriesData]}
-          prepareForCsv={prepareMetricsLineChartForCsv}
+          data={seriesData}
+          prepareForCsv={multiMergeMetaIntoResults}
           filename={`compare_${viewMetric.value}_${chartId}`}
         />
       </StatusWrapper>

--- a/src/components/CompareTimeSeriesCharts/CompareTimeSeriesCharts.jsx
+++ b/src/components/CompareTimeSeriesCharts/CompareTimeSeriesCharts.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent, PropTypes } from 'react';
 import AutoWidth from 'react-auto-width';
+import { prepareMetricsLineChartForCsv } from '../../utils/exports';
 
 import {
   ChartExportControls,
@@ -72,8 +73,10 @@ export default class CompareTimeSeriesCharts extends PureComponent {
           />
         </AutoWidth>
         <ChartExportControls
+          className="for-line-chart"
           chartId={chartId}
-          data={seriesData}
+          data={[seriesData]}
+          prepareForCsv={prepareMetricsLineChartForCsv}
           filename={`compare_${viewMetric.value}_${chartId}`}
         />
       </StatusWrapper>

--- a/src/containers/ComparePage/ComparePage.jsx
+++ b/src/containers/ComparePage/ComparePage.jsx
@@ -18,7 +18,7 @@ import * as LocationTransitIspActions from '../../redux/locationTransitIsp/actio
 import * as ClientIspTransitIspActions from '../../redux/clientIspTransitIsp/actions';
 import * as LocationClientIspTransitIspActions from '../../redux/locationClientIspTransitIsp/actions';
 
-import { prepareMetricsLineChartForCsv } from '../../utils/exports';
+import { multiMergeMetaIntoResults } from '../../utils/exports';
 import timeAggregationFromDates from '../../utils/timeAggregationFromDates';
 import { facetTypes } from '../../constants';
 
@@ -606,8 +606,8 @@ class ComparePage extends PureComponent {
         <ChartExportControls
           className="for-line-chart"
           chartId={chartId}
-          data={[seriesData]}
-          prepareForCsv={prepareMetricsLineChartForCsv}
+          data={seriesData}
+          prepareForCsv={multiMergeMetaIntoResults}
           filename={`compare_${viewMetric.value}_${chartId}`}
         />
       </StatusWrapper>

--- a/src/containers/ComparePage/ComparePage.jsx
+++ b/src/containers/ComparePage/ComparePage.jsx
@@ -18,6 +18,7 @@ import * as LocationTransitIspActions from '../../redux/locationTransitIsp/actio
 import * as ClientIspTransitIspActions from '../../redux/clientIspTransitIsp/actions';
 import * as LocationClientIspTransitIspActions from '../../redux/locationClientIspTransitIsp/actions';
 
+import { prepareMetricsLineChartForCsv } from '../../utils/exports';
 import timeAggregationFromDates from '../../utils/timeAggregationFromDates';
 import { facetTypes } from '../../constants';
 
@@ -603,8 +604,10 @@ class ComparePage extends PureComponent {
           />
         </AutoWidth>
         <ChartExportControls
+          className="for-line-chart"
           chartId={chartId}
-          data={seriesData}
+          data={[seriesData]}
+          prepareForCsv={prepareMetricsLineChartForCsv}
           filename={`compare_${viewMetric.value}_${chartId}`}
         />
       </StatusWrapper>

--- a/src/containers/LocationPage/LocationPage.jsx
+++ b/src/containers/LocationPage/LocationPage.jsx
@@ -14,7 +14,7 @@ import * as LocationsActions from '../../redux/locations/actions';
 import * as LocationClientIspActions from '../../redux/locationClientIsp/actions';
 
 import timeAggregationFromDates from '../../utils/timeAggregationFromDates';
-import { prepareMetricsLineChartForCsv } from '../../utils/exports';
+import { prepareMetricsLineChartForCsv, mergeMetaIntoResults } from '../../utils/exports';
 import { metrics } from '../../constants';
 
 import {
@@ -542,7 +542,8 @@ class LocationPage extends PureComponent {
             </AutoWidth>
             <ChartExportControls
               chartId={chartId}
-              data={hourlyData.results}
+              data={hourlyData}
+              prepareForCsv={mergeMetaIntoResults}
               filename={`${locationId}${id === locationId ? '' : `_${id}`}_${viewMetric.value}_${chartId}`}
             />
           </StatusWrapper>

--- a/src/containers/LocationPage/LocationPage.jsx
+++ b/src/containers/LocationPage/LocationPage.jsx
@@ -459,6 +459,7 @@ class LocationPage extends PureComponent {
             />
           </AutoWidth>
           <ChartExportControls
+            className="for-line-chart"
             chartId={chartId}
             data={[clientIspTimeSeries, locationTimeSeries]}
             prepareForCsv={prepareMetricsLineChartForCsv}
@@ -541,6 +542,7 @@ class LocationPage extends PureComponent {
               />
             </AutoWidth>
             <ChartExportControls
+              className="for-hour-chart"
               chartId={chartId}
               data={hourlyData}
               prepareForCsv={mergeMetaIntoResults}

--- a/src/containers/LocationPage/LocationPage.jsx
+++ b/src/containers/LocationPage/LocationPage.jsx
@@ -14,6 +14,7 @@ import * as LocationsActions from '../../redux/locations/actions';
 import * as LocationClientIspActions from '../../redux/locationClientIsp/actions';
 
 import timeAggregationFromDates from '../../utils/timeAggregationFromDates';
+import { prepareMetricsLineChartForCsv } from '../../utils/exports';
 import { metrics } from '../../constants';
 
 import {
@@ -459,7 +460,8 @@ class LocationPage extends PureComponent {
           </AutoWidth>
           <ChartExportControls
             chartId={chartId}
-            data={locationTimeSeries && locationTimeSeries.results}
+            data={[clientIspTimeSeries, locationTimeSeries]}
+            prepareForCsv={prepareMetricsLineChartForCsv}
             filename={`${locationId}_${viewMetric.value}_${chartId}`}
           />
         </StatusWrapper>

--- a/src/containers/LocationPage/LocationPage.jsx
+++ b/src/containers/LocationPage/LocationPage.jsx
@@ -14,7 +14,7 @@ import * as LocationsActions from '../../redux/locations/actions';
 import * as LocationClientIspActions from '../../redux/locationClientIsp/actions';
 
 import timeAggregationFromDates from '../../utils/timeAggregationFromDates';
-import { prepareMetricsLineChartForCsv, mergeMetaIntoResults } from '../../utils/exports';
+import { multiMergeMetaIntoResults, mergeMetaIntoResults } from '../../utils/exports';
 import { metrics } from '../../constants';
 
 import {
@@ -461,8 +461,8 @@ class LocationPage extends PureComponent {
           <ChartExportControls
             className="for-line-chart"
             chartId={chartId}
-            data={[clientIspTimeSeries, locationTimeSeries]}
-            prepareForCsv={prepareMetricsLineChartForCsv}
+            data={[...clientIspTimeSeries, locationTimeSeries]}
+            prepareForCsv={multiMergeMetaIntoResults}
             filename={`${locationId}_${viewMetric.value}_${chartId}`}
           />
         </StatusWrapper>

--- a/src/utils/exports.js
+++ b/src/utils/exports.js
@@ -80,7 +80,7 @@ export function createCsv(data) {
  * Take metrics data of form { meta, results: [...] } and flatten it
  * to integrate meta into each result item
  */
-function mergeMetaIntoResults({ meta = {}, results = [] } = {}) {
+export function mergeMetaIntoResults({ meta = {}, results = [] } = {}) {
   return results.map(d => ({ ...meta, ...d }));
 }
 

--- a/src/utils/exports.js
+++ b/src/utils/exports.js
@@ -2,6 +2,7 @@
  * Module for handling exporting data (e.g. as JSON or CSV)
  */
 import { encodeDate } from './serialization';
+import moment from 'moment';
 
 /**
  * Create a Blob object from the data string
@@ -63,7 +64,7 @@ export function createCsv(data) {
       // escape double quotes for strings and wrap them in double quotes
       if (typeof value === 'string') {
         return `"${value.replace(/"/g, '""')}"`;
-      } else if (value instanceof Date) {
+      } else if (value instanceof Date || moment.isMoment(value)) {
         return encodeDate(value);
       }
 
@@ -73,4 +74,25 @@ export function createCsv(data) {
 
   // join all lines with new line character to make one big string and return it
   return `${[columns.join(','), ...lines].join('\n')}\n`;
+}
+
+/**
+ * Take metrics data of form { meta, results: [...] } and flatten it
+ * to integrate meta into each result item
+ */
+function mergeMetaIntoResults({ meta = {}, results = [] } = {}) {
+  return results.map(d => ({ ...meta, ...d }));
+}
+
+/**
+ * Take metrics data for line charts and convertthem for CSV.
+ * Uses mergeMetaIntoResults.
+ */
+export function prepareMetricsLineChartForCsv(data = []) {
+  const [series = [], annotationSeries = []] = data;
+
+  return [].concat(series, annotationSeries).reduce((combined, dataset) => {
+    const flattened = mergeMetaIntoResults(dataset);
+    return combined.concat(flattened);
+  }, []);
 }

--- a/src/utils/exports.js
+++ b/src/utils/exports.js
@@ -85,13 +85,11 @@ export function mergeMetaIntoResults({ meta = {}, results = [] } = {}) {
 }
 
 /**
- * Take metrics data for line charts and convertthem for CSV.
- * Uses mergeMetaIntoResults.
+ * Applies mergeMetaIntoResults into multiple datasets and flattens the result
+ * into a single array.
  */
-export function prepareMetricsLineChartForCsv(data = []) {
-  const [series = [], annotationSeries = []] = data;
-
-  return [].concat(series, annotationSeries).reduce((combined, dataset) => {
+export function multiMergeMetaIntoResults(datasets = []) {
+  return datasets.filter(d => d != null).reduce((combined, dataset) => {
     const flattened = mergeMetaIntoResults(dataset);
     return combined.concat(flattened);
   }, []);


### PR DESCRIPTION
Fixes CSV and JSON export for charts that have chart export controls. Note that not all charts do, just line charts and hour charts. See #137 for adding more. Resolves #20.