### PR TITLE
Allow empty arrays to be encoded in the URL

### DIFF
--- a/src/url/UrlHandler.js
+++ b/src/url/UrlHandler.js
@@ -82,8 +82,8 @@ export default class UrlHandler {
       },
     };
 
-    // remove if it is an empty string when encoded
-    if (encoded === '') {
+    // remove if it is an empty string when encoded unless it is an empty array
+    if (encoded === '' && !Array.isArray(value)) {
       delete newLocation.query[urlKey];
     }
 

--- a/src/utils/serialization.js
+++ b/src/utils/serialization.js
@@ -118,8 +118,10 @@ export function encodeArray(any, entrySeparator = '_') {
  * @return {Any} The javascript representation
  */
 export function decodeArray(arrayStr, entrySeparator = '_') {
-  if (!arrayStr) {
+  if (arrayStr == null) {
     return undefined;
+  } else if (arrayStr === '') {
+    return [];
   }
 
   return arrayStr.split(entrySeparator);


### PR DESCRIPTION
Resolves #28 by letting empty arrays be encoded in the URL (e.g. `?isps=&...`