### PR TITLE
Add `set` as a URL query param type.

### DIFF
--- a/src/containers/ComparePage/ComparePage.jsx
+++ b/src/containers/ComparePage/ComparePage.jsx
@@ -52,9 +52,9 @@ const urlQueryConfig = {
   startDate: { type: 'date', urlKey: 'start', defaultValue: moment('2015-10-1') },
   endDate: { type: 'date', urlKey: 'end', defaultValue: moment('2015-11-1') },
   timeAggregation: { type: 'string', urlKey: 'aggr' },
-  facetItemIds: { type: 'array', urlKey: 'selected', persist: false },
-  filter1Ids: { type: 'array', urlKey: 'filter1', persist: false },
-  filter2Ids: { type: 'array', urlKey: 'filter2', persist: false },
+  facetItemIds: { type: 'set', urlKey: 'selected', persist: false },
+  filter1Ids: { type: 'set', urlKey: 'filter1', persist: false },
+  filter2Ids: { type: 'set', urlKey: 'filter2', persist: false },
 };
 const urlHandler = new UrlHandler(urlQueryConfig, browserHistory);
 

--- a/src/containers/DataPage/DataPage.jsx
+++ b/src/containers/DataPage/DataPage.jsx
@@ -41,9 +41,9 @@ const urlQueryConfig = {
   startDate: { type: 'date', urlKey: 'start', defaultValue: moment('2015-10-1') },
   endDate: { type: 'date', urlKey: 'end', defaultValue: moment('2015-11-1') },
   timeAggregation: { type: 'string', urlKey: 'aggr' },
-  clientIspIds: { type: 'array', urlKey: 'clientIsps', defaultValue: [] },
-  transitIspIds: { type: 'array', urlKey: 'transitIsps', defaultValue: [] },
-  locationIds: { type: 'array', urlKey: 'locations', defaultValue: [] },
+  clientIspIds: { type: 'set', urlKey: 'clientIsps', defaultValue: [] },
+  transitIspIds: { type: 'set', urlKey: 'transitIsps', defaultValue: [] },
+  locationIds: { type: 'set', urlKey: 'locations', defaultValue: [] },
 };
 const urlHandler = new UrlHandler(urlQueryConfig, browserHistory);
 function mapStateToProps(state, propsWithUrl) {

--- a/src/containers/LocationPage/LocationPage.jsx
+++ b/src/containers/LocationPage/LocationPage.jsx
@@ -57,7 +57,7 @@ const urlQueryConfig = {
   startDate: { type: 'date', urlKey: 'start', defaultValue: moment('2015-10-1') },
   endDate: { type: 'date', urlKey: 'end', defaultValue: moment('2015-11-1') },
   timeAggregation: { type: 'string', urlKey: 'aggr' },
-  selectedClientIspIds: { type: 'array', urlKey: 'isps', persist: false },
+  selectedClientIspIds: { type: 'set', urlKey: 'isps', persist: false },
 };
 const urlHandler = new UrlHandler(urlQueryConfig, browserHistory);
 

--- a/src/utils/serialization.js
+++ b/src/utils/serialization.js
@@ -98,23 +98,25 @@ export function decodeJson(jsonStr) {
 }
 
 /**
- * Encodes anything as a JSON string.
+ * Encodes an array as a string
  *
- * @param {Any} any The thing to be encoded
- * @return {String} The JSON string representation of any
+ * @param {Array} array The array to be encoded
+ * @param {String} entrySeparator="_" The separator between entries
+ * @return {String} The JSON string representation of the array
  */
-export function encodeArray(any, entrySeparator = '_') {
-  if (!any) {
+export function encodeArray(array, entrySeparator = '_') {
+  if (!array) {
     return undefined;
   }
 
-  return any.join(entrySeparator);
+  return array.join(entrySeparator);
 }
 
 /**
- * Decodes a JSON string into javascript
+ * Decodes an array string into a javascript array
  *
- * @param {String} jsonStr The JSON string representation
+ * @param {String} arrayStr The array string representation
+ * @param {String} entrySeparator="_" The separator between entries
  * @return {Any} The javascript representation
  */
 export function decodeArray(arrayStr, entrySeparator = '_') {
@@ -126,6 +128,41 @@ export function decodeArray(arrayStr, entrySeparator = '_') {
 
   return arrayStr.split(entrySeparator);
 }
+
+/**
+ * Encodes a set (an array with unique values) as a string
+ *
+ * @param {Array} set The set to be encoded
+ * @param {String} entrySeparator="_" The separator between entries
+ * @return {String} The JSON string representation of the set
+ */
+export function encodeSet(set, entrySeparator = '_') {
+  if (!set) {
+    return undefined;
+  }
+
+  const filtered = set.filter((d, i) => set.indexOf(d) === i);
+  return encodeArray(filtered, entrySeparator);
+}
+
+/**
+ * Decodes a set (an array with unique values) string into a javascript array
+ *
+ * @param {String} setStr The set string representation
+ * @param {String} entrySeparator="_" The separator between entries
+ * @return {Any} The javascript representation
+ */
+export function decodeSet(setStr, entrySeparator = '_') {
+  if (setStr == null) {
+    return undefined;
+  } else if (setStr === '') {
+    return [];
+  }
+
+  const array = decodeArray(setStr, entrySeparator);
+  return array.filter((d, i) => array.indexOf(d) === i);
+}
+
 
 /**
  * Encode simple objects as readable strings. Currently works only for simple,
@@ -191,6 +228,10 @@ export const Decoders = {
     return decodeArray(d);
   },
 
+  set(d) {
+    return decodeSet(d);
+  },
+
   json(d) {
     return decodeJson(d);
   },
@@ -248,6 +289,10 @@ export const Encoders = {
 
   array(d) {
     return encodeArray(d);
+  },
+
+  set(d) {
+    return encodeSet(d);
   },
 
   json(d) {

--- a/src/utils/tests/serialization-test.js
+++ b/src/utils/tests/serialization-test.js
@@ -9,6 +9,8 @@ import {
   decodeJson,
   encodeArray,
   decodeArray,
+  encodeSet,
+  decodeSet,
   encodeObject,
   decodeObject,
   encode,
@@ -99,6 +101,22 @@ describe('utils', () => {
     describe('decodeArray', () => {
       it('produces the correct value', () => {
         const output = decodeArray('a_b_c');
+        const expectedOutput = ['a', 'b', 'c'];
+
+        expect(output).to.deep.equal(expectedOutput);
+      });
+    });
+
+    describe('encodeSet', () => {
+      it('produces the correct value', () => {
+        const input = ['a', 'b', 'c', 'b'];
+        expect(encodeSet(input)).to.equal('a_b_c');
+      });
+    });
+
+    describe('decodeSet', () => {
+      it('produces the correct value', () => {
+        const output = decodeSet('a_b_c_b');
         const expectedOutput = ['a', 'b', 'c'];
 
         expect(output).to.deep.equal(expectedOutput);


### PR DESCRIPTION
- Encodes and decodes arrays to have only unique values. Resolves #43. 
- Used on ID fields for all pages (e.g. selected client ISPs, filter items, etc.)