### PR TITLE
Add threshold support to HourChart, LineChart, LineChartSmallMult

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "d3-geo": "^1.2.5",
     "d3-interpolate": "^1.1.1",
     "d3-interpolate-path": "^1.0.1",
-    "d3-line-chunked": "^1.3.0",
+    "d3-line-chunked": "^1.4.0",
     "d3-scale": "^1.0.3",
     "d3-scale-interactive": "^1.1.3",
     "d3-selection": "^1.0.2",

--- a/src/components/CompareHourCharts/CompareHourCharts.jsx
+++ b/src/components/CompareHourCharts/CompareHourCharts.jsx
@@ -60,7 +60,6 @@ export default class CompareHourCharts extends PureComponent {
             highlightHour={highlightHourly}
             id={chartId}
             onHighlightHour={onHighlightHourly}
-            threshold={30}
             yAxisLabel={viewMetric.label}
             yAxisUnit={viewMetric.unit}
             yExtent={hourlyData.extents[viewMetric.dataKey]}

--- a/src/components/CountChart/CountChart.jsx
+++ b/src/components/CountChart/CountChart.jsx
@@ -1,6 +1,7 @@
 import React, { PureComponent, PropTypes } from 'react';
 import d3 from 'd3';
 import addComputedProps from '../../hoc/addComputedProps';
+import { testThreshold } from '../../constants';
 
 import './CountChart.scss';
 
@@ -94,6 +95,7 @@ class CountChart extends PureComponent {
     padding: PropTypes.object,
     plotAreaHeight: PropTypes.number,
     plotAreaWidth: PropTypes.number,
+    threshold: PropTypes.number,
     width: PropTypes.number,
     xExtent: PropTypes.array,
     xKey: React.PropTypes.string,
@@ -109,6 +111,7 @@ class CountChart extends PureComponent {
     yKey: 'count',
     highlightColor: '#aaa',
     maxBinWidth: 40,
+    threshold: testThreshold,
   };
 
   /**
@@ -233,6 +236,7 @@ class CountChart extends PureComponent {
       yScale,
       binWidth,
       plotAreaHeight,
+      threshold,
     } = this.props;
 
     const d3Color = d3.color(color);
@@ -248,8 +252,8 @@ class CountChart extends PureComponent {
         .attr('width', binWidth)
         .attr('height', 0)
         .style('shape-rendering', 'crispEdges')
-        .style('fill', d => (d.belowThreshold ? '#fff' : lighterColor))
-        .style('stroke', d => (d.belowThreshold ? '#ddd' : color));
+        .style('fill', d => (d.count < threshold ? '#fff' : lighterColor))
+        .style('stroke', d => (d.count < threshold ? '#ddd' : color));
 
     if (addHandlers) {
       entering
@@ -264,8 +268,8 @@ class CountChart extends PureComponent {
       .transition()
         .attr('y', d => yScale(d[yKey] || 0))
         .attr('height', d => plotAreaHeight - yScale(d[yKey] || 0))
-        .style('fill', d => (d.belowThreshold ? '#fff' : lighterColor))
-        .style('stroke', d => (d.belowThreshold ? '#ddd' : color));
+        .style('fill', d => (d.count < threshold ? '#fff' : lighterColor))
+        .style('stroke', d => (d.count < threshold ? '#ddd' : color));
 
 
     // EXIT

--- a/src/components/CountChart/CountChart.jsx
+++ b/src/components/CountChart/CountChart.jsx
@@ -241,6 +241,9 @@ class CountChart extends PureComponent {
 
     const d3Color = d3.color(color);
     const lighterColor = d3Color ? d3Color.brighter(0.3) : undefined;
+    const belowThresholdFill = d3.color(lighterColor);
+    belowThresholdFill.opacity = 0.2;
+    const belowThresholdStroke = belowThresholdFill.darker(0.3);
 
     const binding = root.selectAll('rect').data(data);
 
@@ -252,8 +255,8 @@ class CountChart extends PureComponent {
         .attr('width', binWidth)
         .attr('height', 0)
         .style('shape-rendering', 'crispEdges')
-        .style('fill', d => (d.count < threshold ? '#fff' : lighterColor))
-        .style('stroke', d => (d.count < threshold ? '#ddd' : color));
+        .style('fill', d => (d.count < threshold ? belowThresholdFill : lighterColor))
+        .style('stroke', d => (d.count < threshold ? belowThresholdStroke : color));
 
     if (addHandlers) {
       entering
@@ -268,9 +271,8 @@ class CountChart extends PureComponent {
       .transition()
         .attr('y', d => yScale(d[yKey] || 0))
         .attr('height', d => plotAreaHeight - yScale(d[yKey] || 0))
-        .style('fill', d => (d.count < threshold ? '#fff' : lighterColor))
-        .style('stroke', d => (d.count < threshold ? '#ddd' : color));
-
+        .style('fill', d => (d.count < threshold ? belowThresholdFill : lighterColor))
+        .style('stroke', d => (d.count < threshold ? belowThresholdStroke : color));
 
     // EXIT
     binding.exit()

--- a/src/components/HourChart/HourChart.jsx
+++ b/src/components/HourChart/HourChart.jsx
@@ -10,8 +10,18 @@ import './HourChart.scss';
  * based on the props of the component
  */
 function visProps(props) {
-  const { data, forceZeroMin, height, paddingLeft = 50, paddingRight = 20,
-    width, yExtent, yKey } = props;
+  const {
+    color,
+    data,
+    forceZeroMin,
+    height,
+    paddingLeft = 50,
+    paddingRight = 20,
+    threshold,
+    width,
+    yExtent,
+    yKey
+  } = props;
   let { xScale } = props;
 
   const padding = {
@@ -47,10 +57,15 @@ function visProps(props) {
   const binWidth = (xMax - yMax) / 24;
 
   // function to generate paths for each series
-  const line = d3.line()
+  const lineChunked = d3.lineChunked()
     .curve(d3.curveMonotoneX)
     .x((d) => xScale(d.hour) + (binWidth / 2))
-    .y((d) => yScale(d[yKey]));
+    .y((d) => yScale(d[yKey]))
+    .defined(d => d[yKey] != null && d.count > threshold)
+    .lineStyles({
+      stroke: color,
+      'stroke-width': 1.5,
+    });
 
   return {
     binWidth,
@@ -59,7 +74,7 @@ function visProps(props) {
     plotAreaHeight,
     padding,
     plotAreaWidth,
-    line,
+    lineChunked,
     width,
     xScale,
     yScale,
@@ -97,7 +112,7 @@ class HourChart extends PureComponent {
     highlightHour: PropTypes.number,
     id: React.PropTypes.string,
     inSvg: React.PropTypes.bool,
-    line: PropTypes.func,
+    lineChunked: PropTypes.func,
     onHighlightHour: PropTypes.func,
     overallData: PropTypes.array,
     padding: PropTypes.object,
@@ -341,8 +356,19 @@ class HourChart extends PureComponent {
   }
 
   updateOverallLine() {
-    const { overallData, color } = this.props;
-    this.updateLine(overallData, this.gOverallLine, { stroke: color });
+    const { overallData, lineChunked } = this.props;
+
+    const binding = this.gOverallLine.selectAll('g').data([overallData]);
+
+    // ENTER
+    const entering = binding.enter().append('g');
+
+    // ENTER + UPDATE
+    binding.merge(entering)
+      .call(lineChunked);
+
+    // EXIT
+    binding.exit().remove();
   }
 
   /**
@@ -416,27 +442,6 @@ class HourChart extends PureComponent {
         .text(highlightPoint.hour);
     }
   }
-
-  /**
-   * Render a line
-   */
-  updateLine(dateData, parent, options = {}) {
-    const { line } = this.props;
-
-    // draw the line
-    const lineBinding = parent.selectAll('path').data([dateData]);
-
-    const lineEntering = lineBinding.enter()
-      .append('path')
-      .style('fill', 'none');
-
-    lineBinding.merge(lineEntering)
-      .style('stroke', options.stroke || '#c0c')
-      .attr('d', line);
-
-    lineBinding.exit().remove();
-  }
-
 
   /**
    * The main render method. Defers chart rendering to d3 in `update` and `setup`

--- a/src/components/HourChart/HourChart.jsx
+++ b/src/components/HourChart/HourChart.jsx
@@ -1,6 +1,7 @@
 import React, { PureComponent, PropTypes } from 'react';
 import d3 from 'd3';
 import addComputedProps from '../../hoc/addComputedProps';
+import { testThreshold } from '../../constants';
 
 import './HourChart.scss';
 
@@ -119,7 +120,7 @@ class HourChart extends PureComponent {
     data: [],
     color: '#aaa',
     forceZeroMin: true,
-    threshold: 30,
+    threshold: testThreshold,
     yFormatter: d => d,
     yKey: 'y',
   }

--- a/src/components/HourChart/HourChart.jsx
+++ b/src/components/HourChart/HourChart.jsx
@@ -2,6 +2,7 @@ import React, { PureComponent, PropTypes } from 'react';
 import d3 from 'd3';
 import addComputedProps from '../../hoc/addComputedProps';
 import { testThreshold } from '../../constants';
+import { standardLineChunkedDefinitions } from '../../utils/chart';
 
 import './HourChart.scss';
 
@@ -20,7 +21,7 @@ function visProps(props) {
     threshold,
     width,
     yExtent,
-    yKey
+    yKey,
   } = props;
   let { xScale } = props;
 
@@ -61,11 +62,13 @@ function visProps(props) {
     .curve(d3.curveMonotoneX)
     .x((d) => xScale(d.hour) + (binWidth / 2))
     .y((d) => yScale(d[yKey]))
-    .defined(d => d[yKey] != null && d.count > threshold)
+    .defined(d => d[yKey] != null)
     .lineStyles({
       stroke: color,
       'stroke-width': 1.5,
-    });
+    })
+    .chunk(d => (d.count > threshold ? 'line' : 'below-threshold'))
+    .chunkDefinitions(standardLineChunkedDefinitions());
 
   return {
     binWidth,

--- a/src/components/HourChart/HourChartWithCounts.jsx
+++ b/src/components/HourChart/HourChartWithCounts.jsx
@@ -4,6 +4,7 @@ import d3 from 'd3';
 import { HourChart, CountChart } from '../../components';
 import { sum, average } from '../../utils/math';
 import addComputedProps from '../../hoc/addComputedProps';
+import { testThreshold } from '../../constants';
 
 
 /**
@@ -12,7 +13,7 @@ import addComputedProps from '../../hoc/addComputedProps';
  * @return {Object} the prepared data { filteredData, dataByHour, dataByDate }
  */
 function prepareData(props) {
-  const { data, yKey, threshold } = props;
+  const { data, yKey } = props;
 
   // filter so all data has a value for yKey
   const filteredData = (data || []).filter(d => d[yKey] != null);
@@ -29,7 +30,6 @@ function prepareData(props) {
       hour,
       points: hourPoints || [],
       count,
-      belowThreshold: count < threshold,
       overall: average(hourPoints, yKey),
     };
   });
@@ -44,7 +44,6 @@ function prepareData(props) {
       date: datePoints[0].date,
       points: datePoints,
       count,
-      belowThreshold: count < threshold,
     };
 
     return byDate;
@@ -135,7 +134,7 @@ class HourChartWithCounts extends PureComponent {
   }
 
   static defaultProps = {
-    threshold: 30,
+    threshold: testThreshold,
   }
 
   /**

--- a/src/components/HourChart/HourChartWithCounts.jsx
+++ b/src/components/HourChart/HourChartWithCounts.jsx
@@ -53,6 +53,7 @@ function prepareData(props) {
   const overallData = dataByHour.map(d => ({
     [yKey]: d.overall,
     hour: d.hour,
+    count: d.count,
   })).filter(d => d[yKey] != null);
 
   return {

--- a/src/components/LineChart/LineChart.jsx
+++ b/src/components/LineChart/LineChart.jsx
@@ -2,6 +2,7 @@ import React, { PureComponent, PropTypes } from 'react';
 import d3 from 'd3';
 import { multiExtent, findClosestSorted, findEqualSorted } from '../../utils/array';
 import { colorsFor } from '../../utils/color';
+import { standardLineChunkedDefinitions } from '../../utils/chart';
 import { Legend } from '../../d3-components';
 import addComputedProps from '../../hoc/addComputedProps';
 import { testThreshold } from '../../constants';
@@ -109,12 +110,15 @@ function visProps(props) {
     .x((d) => xScale(d[xKey]))
     .y((d) => yScale(d[yKey]))
     .curve(d3.curveMonotoneX)
-    .defined(d => d[yKey] != null && d.count > threshold)
+    .defined(d => d[yKey] != null)
     .accessData(d => d.results)
     .lineStyles({
       stroke: (d) => colors[d.meta[idKey]] || '#aaa',
       'stroke-width': 1.5,
-    });
+    })
+    .chunk(d => (d.count > threshold ? 'line' : 'below-threshold'))
+    .chunkDefinitions(standardLineChunkedDefinitions());
+
 
   // function to generate paths for each annotation series
   const annotationLineChunked = d3.lineChunked()
@@ -126,7 +130,9 @@ function visProps(props) {
     .lineStyles({
       stroke: '#aaa',
       'stroke-width': 1,
-    });
+    })
+    .chunk(d => (d.count > threshold ? 'line' : 'below-threshold'))
+    .chunkDefinitions(standardLineChunkedDefinitions());
 
 
   return {

--- a/src/components/LineChart/LineChart.jsx
+++ b/src/components/LineChart/LineChart.jsx
@@ -4,6 +4,7 @@ import { multiExtent, findClosestSorted, findEqualSorted } from '../../utils/arr
 import { colorsFor } from '../../utils/color';
 import { Legend } from '../../d3-components';
 import addComputedProps from '../../hoc/addComputedProps';
+import { testThreshold } from '../../constants';
 
 import './LineChart.scss';
 
@@ -20,6 +21,7 @@ function visProps(props) {
     height,
     paddingLeft = 50,
     paddingRight = 20,
+    threshold,
     width,
     xExtent,
     xKey,
@@ -107,7 +109,7 @@ function visProps(props) {
     .x((d) => xScale(d[xKey]))
     .y((d) => yScale(d[yKey]))
     .curve(d3.curveMonotoneX)
-    .defined(d => d[yKey] != null)
+    .defined(d => d[yKey] != null && d.count > threshold)
     .accessData(d => d.results)
     .lineStyles({
       stroke: (d) => colors[d.meta[idKey]] || '#aaa',
@@ -185,6 +187,7 @@ class LineChart extends PureComponent {
     plotAreaHeight: PropTypes.number,
     plotAreaWidth: PropTypes.number,
     series: PropTypes.array,
+    threshold: PropTypes.number,
     width: React.PropTypes.number,
     xExtent: PropTypes.array,
     xKey: React.PropTypes.string,
@@ -201,6 +204,7 @@ class LineChart extends PureComponent {
     forceZeroMin: true,
     idKey: 'id',
     labelKey: 'label',
+    threshold: testThreshold,
     xKey: 'x',
     yFormatter: d => d,
     yKey: 'y',

--- a/src/components/LineChart/LineChartWithCounts.jsx
+++ b/src/components/LineChart/LineChartWithCounts.jsx
@@ -5,6 +5,7 @@ import { colorsFor } from '../../utils/color';
 import { LineChart, CountChart } from '../../components';
 import { multiExtent } from '../../utils/array';
 import addComputedProps from '../../hoc/addComputedProps';
+import { testThreshold } from '../../constants';
 
 /**
  * Filter the data
@@ -156,7 +157,7 @@ class LineChartWithCounts extends PureComponent {
   }
 
   static defaultProps = {
-    threshold: 30,
+    threshold: testThreshold,
     idKey: 'id',
     labelKey: 'label',
   }

--- a/src/components/LineChartSmallMult/LineChartSmallMult.jsx
+++ b/src/components/LineChartSmallMult/LineChartSmallMult.jsx
@@ -2,6 +2,7 @@ import React, { PureComponent, PropTypes } from 'react';
 import d3 from 'd3';
 import { multiExtent, findClosestSorted } from '../../utils/array';
 import { colorsFor } from '../../utils/color';
+import { standardLineChunkedDefinitions } from '../../utils/chart';
 import { TextWithBackground } from '../../components';
 import addComputedProps from '../../hoc/addComputedProps';
 import { testThreshold } from '../../constants';
@@ -102,13 +103,15 @@ function visProps(props) {
         .x((d) => xScale(d[xKey]))
         .y((d) => yScale(d[metrics[yIndex].dataKey]))
         .curve(d3.curveMonotoneX)
-        .defined(d => d[metrics[yIndex].dataKey] != null && d.count > threshold)
+        .defined(d => d[metrics[yIndex].dataKey] != null)
         .accessData(d => d.results)
         .lineStyles({
           // first element is baseline value
           stroke: (d, i) => ((showBaseline && i === 0) ? '#bbb' : colors[d.meta.client_asn_number]),
           'stroke-width': (d, i) => ((showBaseline && i === 0) ? 1 : 1.5),
         })
+        .chunk(d => (d.count > threshold ? 'line' : 'below-threshold'))
+        .chunkDefinitions(standardLineChunkedDefinitions())
     );
   }
 

--- a/src/components/LineChartSmallMult/LineChartSmallMult.jsx
+++ b/src/components/LineChartSmallMult/LineChartSmallMult.jsx
@@ -4,6 +4,7 @@ import { multiExtent, findClosestSorted } from '../../utils/array';
 import { colorsFor } from '../../utils/color';
 import { TextWithBackground } from '../../components';
 import addComputedProps from '../../hoc/addComputedProps';
+import { testThreshold } from '../../constants';
 
 import './LineChartSmallMult.scss';
 
@@ -21,6 +22,7 @@ function visProps(props) {
     xKey,
     metrics,
     smallMultHeight,
+    threshold,
   } = props;
   let { xScale } = props;
 
@@ -100,7 +102,7 @@ function visProps(props) {
         .x((d) => xScale(d[xKey]))
         .y((d) => yScale(d[metrics[yIndex].dataKey]))
         .curve(d3.curveMonotoneX)
-        .defined(d => d[metrics[yIndex].dataKey] != null)
+        .defined(d => d[metrics[yIndex].dataKey] != null && d.count > threshold)
         .accessData(d => d.results)
         .lineStyles({
           // first element is baseline value
@@ -155,6 +157,7 @@ class LineChartSmallMult extends PureComponent {
     smallMultHeight: PropTypes.number,
     smallMultMargin: PropTypes.number,
     smallMultWidth: PropTypes.number,
+    threshold: PropTypes.number,
     width: React.PropTypes.number,
     xExtent: PropTypes.array,
     xKey: PropTypes.string,
@@ -168,6 +171,7 @@ class LineChartSmallMult extends PureComponent {
     showBaseline: true,
     xKey: 'date',
     metrics: [],
+    threshold: testThreshold,
   }
 
   constructor(props) {

--- a/src/constants.js
+++ b/src/constants.js
@@ -64,3 +64,5 @@ export const facetTypes = [
     labelKey: 'server_asn_name',
   },
 ];
+
+export const testThreshold = 30;

--- a/src/containers/LocationPage/LocationPage.jsx
+++ b/src/containers/LocationPage/LocationPage.jsx
@@ -549,7 +549,6 @@ class LocationPage extends PureComponent {
                 highlightHour={highlightHourly}
                 id={chartId}
                 onHighlightHour={this.onHighlightHourly}
-                threshold={30}
                 yAxisLabel={viewMetric.label}
                 yAxisUnit={viewMetric.unit}
                 yExtent={hourlyData.extents[extentKey]}

--- a/src/utils/chart.js
+++ b/src/utils/chart.js
@@ -1,0 +1,21 @@
+/**
+ * Helper to create the standard line chunked definitions that we use
+ * in various lines throughout the project.
+ *
+ * @param {Function|String} color the color of the the line (typical d3.. takes arg `d`)
+ */
+export function standardLineChunkedDefinitions() {
+  return {
+    gap: {
+      styles: {
+        'stroke-width': 0,
+      },
+    },
+    'below-threshold': {
+      styles: {
+        'stroke-dasharray': '2, 2',
+        'stroke-opacity': 0.35,
+      },
+    },
+  };
+}


### PR DESCRIPTION
- See #113 for discussion.
- Moves threshold count to a single constant in constants.js called `testThreshold`
- Add threshold support to HourChart, LineChart, LineChartSmallMult
- Resolves #113.