### PR TITLE
truncate names.

### DIFF
--- a/src/components/HistoGroup/HistoGroup.jsx
+++ b/src/components/HistoGroup/HistoGroup.jsx
@@ -63,7 +63,7 @@ export default class HistoGroup extends PureComponent {
 
     return (
       <Col md={4} key={info.id}>
-        <h5>{info.label}</h5>
+        <h5 className="truncate">{info.label}</h5>
         <Histogram
           bins={bins}
           width={width}

--- a/src/components/HistoGroup/HistoGroup.scss
+++ b/src/components/HistoGroup/HistoGroup.scss
@@ -1,0 +1,6 @@
+
+.truncate {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}


### PR DESCRIPTION
uses same truncate with ellipses  css concept as other places. 

<img width="764" alt="screen shot 2016-10-18 at 1 10 42 pm" src="https://cloud.githubusercontent.com/assets/9369/19494549/8e2db942-9534-11e6-8b4a-ca14a8a2b9a3.png">

to close #170 