### PR TITLE
Add support for show baselines, show regional values, remove show baseline toggle

### DIFF
--- a/src/components/LineChart/LineChart.jsx
+++ b/src/components/LineChart/LineChart.jsx
@@ -84,7 +84,8 @@ function visProps(props) {
   }
   let yDomain = yExtent;
   if (!yDomain) {
-    yDomain = multiExtent(combinedData, d => d[yKey], oneSeries => oneSeries.results);
+    yDomain = multiExtent(combinedData, d => d[yKey], oneSeries => oneSeries.results) || [];
+
     if (yDomain[0] == null) {
       yDomain[0] = 0;
     }
@@ -137,7 +138,8 @@ function visProps(props) {
       'stroke-width': 1,
     })
     .chunk(d => (d.count > threshold ? 'line' : 'below-threshold'))
-    .chunkDefinitions(standardLineChunkedDefinitions());
+    .chunkDefinitions(standardLineChunkedDefinitions())
+    .transitionInitial(false);
 
 
   return {
@@ -535,8 +537,6 @@ class LineChart extends PureComponent {
       this.annotationLines.selectAll('*').remove();
       return;
     }
-
-    console.log('annotationSeries', annotationSeries);
 
     // handle normal lines via line chunked
     const normalLines = annotationSeries.filter(oneSeries => Array.isArray(oneSeries.results));

--- a/src/components/LineChart/LineChart.jsx
+++ b/src/components/LineChart/LineChart.jsx
@@ -85,6 +85,12 @@ function visProps(props) {
   let yDomain = yExtent;
   if (!yDomain) {
     yDomain = multiExtent(combinedData, d => d[yKey], oneSeries => oneSeries.results);
+    if (yDomain[0] == null) {
+      yDomain[0] = 0;
+    }
+    if (yDomain[1] == null) {
+      yDomain[1] = 1;
+    }
   }
 
   // force 0 as the min in the yDomain if specified
@@ -103,7 +109,6 @@ function visProps(props) {
   if (yDomain) {
     yScale.domain(yDomain);
   }
-
 
   // function to generate paths for each series
   const lineChunked = d3.lineChunked()
@@ -524,14 +529,19 @@ class LineChart extends PureComponent {
    * Render the annotation lines in the chart
    */
   updateAnnotationLines() {
-    const { annotationSeries, annotationLineChunked } = this.props;
+    const { annotationSeries, annotationLineChunked, xScale, yScale, yKey } = this.props;
 
     if (!annotationSeries || !annotationSeries.length) {
       this.annotationLines.selectAll('*').remove();
       return;
     }
 
-    const binding = this.annotationLines.selectAll('g').data(annotationSeries);
+    console.log('annotationSeries', annotationSeries);
+
+    // handle normal lines via line chunked
+    const normalLines = annotationSeries.filter(oneSeries => Array.isArray(oneSeries.results));
+
+    const binding = this.annotationLines.selectAll('g').data(normalLines);
 
     // ENTER
     const entering = binding.enter().append('g');
@@ -543,6 +553,22 @@ class LineChart extends PureComponent {
 
     // EXIT
     binding.exit().remove();
+
+    // handle constant lines
+    const constantLines = annotationSeries.filter(oneSeries => !Array.isArray(oneSeries.results));
+    const constantBinding = this.annotationLines.selectAll('.constant-line').data(constantLines);
+    const constantEntering = constantBinding.enter().append('line');
+
+    const [xMin, xMax] = xScale.range();
+
+    constantBinding.merge(constantEntering)
+      .classed('constant-line', true)
+      .attr('x1', xMin)
+      .attr('x2', xMax)
+      .attr('y1', d => yScale(d.results[yKey]))
+      .attr('y2', d => yScale(d.results[yKey]));
+
+    constantBinding.exit().remove();
   }
 
   /**

--- a/src/components/LineChart/LineChart.scss
+++ b/src/components/LineChart/LineChart.scss
@@ -12,4 +12,11 @@
     stroke: rgba(0, 0, 0, 0.2);
     stroke-width: 1px;
   }
+
+  .constant-line {
+    pointer-events: none;
+    stroke-dasharray: 4, 2;
+    stroke: #aaa;
+    stroke-opacity: 0.5;
+  }
 }

--- a/src/containers/LocationPage/LocationPage.jsx
+++ b/src/containers/LocationPage/LocationPage.jsx
@@ -49,7 +49,7 @@ const urlQueryConfig = {
 
   // chart options
   showBaselines: { type: 'boolean', defaultValue: false, urlKey: 'baselines' },
-  showRegionalValues: { type: 'boolean', defaultValue: false, urlKey: 'regional' },
+  showRegionalValues: { type: 'boolean', defaultValue: true, urlKey: 'regional' },
 
   // selected time
   startDate: { type: 'date', urlKey: 'start', defaultValue: defaultStartDate },
@@ -80,6 +80,7 @@ function mapStateToProps(state, propsWithUrl) {
     locationAndClientIspTimeSeries: LocationPageSelectors.getLocationAndClientIspTimeSeries(state, propsWithUrl),
     locationHourly: LocationPageSelectors.getLocationHourly(state, propsWithUrl),
     locationTimeSeries: LocationsSelectors.getLocationTimeSeries(state, propsWithUrl),
+    annotationTimeSeries: LocationPageSelectors.getAnnotationTimeSeries(state, propsWithUrl),
     selectedClientIspInfo: LocationPageSelectors.getLocationSelectedClientIspInfo(state, propsWithUrl),
     summary: LocationPageSelectors.getSummaryData(state, propsWithUrl),
     timeAggregation: LocationPageSelectors.getTimeAggregation(state, propsWithUrl),
@@ -92,6 +93,7 @@ function mapStateToProps(state, propsWithUrl) {
 
 class LocationPage extends PureComponent {
   static propTypes = {
+    annotationTimeSeries: PropTypes.array,
     autoTimeAggregation: PropTypes.bool,
     clientIspHourly: PropTypes.array,
     clientIspTimeSeries: PropTypes.array,
@@ -401,22 +403,25 @@ class LocationPage extends PureComponent {
 
   renderChartOptions() {
     const { showBaselines, showRegionalValues } = this.props;
+    const enableShowBaselinesToggle = false;
     return (
       <div className="chart-options">
         <ul className="list-inline">
-          <li>
-            <div className="checkbox">
-              <label htmlFor="show-baselines">
-                <input
-                  type="checkbox"
-                  checked={showBaselines}
-                  id="show-baselines"
-                  onChange={this.onShowBaselinesChange}
-                />
-                {' Show Baselines'}
-              </label>
-            </div>
-          </li>
+          {enableShowBaselinesToggle ? (
+            <li>
+              <div className="checkbox">
+                <label htmlFor="show-baselines">
+                  <input
+                    type="checkbox"
+                    checked={showBaselines}
+                    id="show-baselines"
+                    onChange={this.onShowBaselinesChange}
+                  />
+                  {' Show Baselines'}
+                </label>
+              </div>
+            </li>
+          ) : null}
           <li>
             <div className="checkbox">
               <label htmlFor="show-regional-values">
@@ -438,7 +443,8 @@ class LocationPage extends PureComponent {
 
   renderCompareProviders() {
     const { clientIspTimeSeries, highlightTimeSeriesDate, highlightTimeSeriesLine,
-      locationId, locationTimeSeries, timeSeriesStatus, viewMetric, colors } = this.props;
+      locationId, locationTimeSeries, timeSeriesStatus, viewMetric, colors,
+      annotationTimeSeries } = this.props;
     const chartId = 'providers-time-series';
     return (
       <div className="subsection">
@@ -451,7 +457,7 @@ class LocationPage extends PureComponent {
               id={chartId}
               colors={colors}
               series={clientIspTimeSeries}
-              annotationSeries={locationTimeSeries}
+              annotationSeries={annotationTimeSeries}
               onHighlightDate={this.onHighlightTimeSeriesDate}
               highlightDate={highlightTimeSeriesDate}
               onHighlightLine={this.onHighlightTimeSeriesLine}

--- a/src/redux/locationPage/selectors.js
+++ b/src/redux/locationPage/selectors.js
@@ -93,6 +93,15 @@ function getLocationSelectedClientIspIds(state, props) {
   return props.selectedClientIspIds;
 }
 
+function getShowRegionalValues(state, props) {
+  return props.showRegionalValues;
+}
+
+function getShowBaselines(state, props) {
+  return props.showBaselines;
+}
+
+
 // ----------------------
 // Selectors
 // ----------------------
@@ -301,5 +310,35 @@ export const getColors = createSelector(
       clientIspId => `${locationId}_${clientIspId}`);
 
     return colors;
+  }
+);
+
+
+/**
+ * Gets the annotation series to show int he main time series chart
+ */
+export const getAnnotationTimeSeries = createSelector(
+  getShowRegionalValues, getShowBaselines, LocationsSelectors.getLocationTimeSeries,
+  (showRegionalValues, showBaselines, locationTimeSeries) => {
+    const results = [];
+
+    if (showRegionalValues && locationTimeSeries) {
+      results.push(locationTimeSeries);
+    }
+
+    if (showBaselines) {
+      // TODO: add in base lines for the chart here.
+      // results.push({
+      //   meta: { id: 'baseline1', label: 'Baseline 1' },
+      //   results: {
+      //     download_speed_mbps_median: 10,
+      //     retransmit_avg: 0.01,
+      //     rtt_avg: 50,
+      //     upload_speed_mbps_median: 2,
+      //   },
+      // });
+    }
+
+    return results;
   }
 );


### PR DESCRIPTION
- adds in basic support for baselines in the line chart, but until we have well defined baselines to use, the toggle has been removed. Also probably some discussion about colors and the label location of baselines should be had.

- makes the show regional values toggle turn on and off the region line in the main chart

Resolves #152 