### PR TITLE
change last week to last 6 months

### DIFF
--- a/src/api/transforms.js
+++ b/src/api/transforms.js
@@ -366,7 +366,7 @@ export function transformFixedData(body) {
   if (body.data) {
     // read in test_counts from meta if available
     if (body.meta) {
-      const testCountFields = ['last_year_test_count', 'last_week_test_count', 'last_month_test_count'];
+      const testCountFields = ['last_year_test_count', 'last_week_test_count', 'last_month_test_count', 'last_six_month_test_count'];
       testCountFields.forEach(field => {
         if (body.meta[field] != null && body.data[field] == null) {
           body.data[field] = body.meta[field];
@@ -378,6 +378,7 @@ export function transformFixedData(body) {
       last_year_: 'lastYear',
       last_month_: 'lastMonth',
       last_week_: 'lastWeek',
+      last_six_months_: 'lastSixMonths',
       other: 'other',
     };
 

--- a/src/components/ScatterPlot/ScatterPlot.jsx
+++ b/src/components/ScatterPlot/ScatterPlot.jsx
@@ -261,8 +261,8 @@ class ScatterPlot extends PureComponent {
       .style('fill', color)
       .text(highlightPoint.label);
 
-    const xValue = highlightPoint[xKey];
-    const yValue = highlightPoint[yKey];
+    const xValue = highlightPoint[xKey] || 0;
+    const yValue = highlightPoint[yKey] || 0;
 
     // show the value in the x axis
     const xAxisY = yScale.range()[0] + 4;
@@ -305,7 +305,9 @@ class ScatterPlot extends PureComponent {
 
     this.g.attr('transform', `translate(${padding.left} ${padding.top})`);
 
-    const binding = this.g.selectAll('.data-point').data(data, d => d.id);
+    const filteredData = data.filter((d) => d[xKey] && d[yKey]);
+
+    const binding = this.g.selectAll('.data-point').data(filteredData, d => d.id);
     binding.exit().remove();
     const entering = binding.enter().append('circle')
       .classed('data-point', true)
@@ -313,8 +315,8 @@ class ScatterPlot extends PureComponent {
       .on('mouseleave', () => this.onHoverPoint(null));
 
     binding.merge(entering)
-      .attr('cx', (d) => xScale(d[xKey]))
-      .attr('cy', (d) => yScale(d[yKey]))
+      .attr('cx', (d) => xScale(d[xKey] || 0))
+      .attr('cy', (d) => yScale(d[yKey] || 0))
       .attr('r', pointRadius)
       .attr('stroke', (d) => colors[d.id])
       .attr('fill', (d) => d3.color(colors[d.id]).brighter(0.3));

--- a/src/containers/LocationPage/LocationPage.jsx
+++ b/src/containers/LocationPage/LocationPage.jsx
@@ -60,8 +60,8 @@ const urlQueryConfig = {
 const urlHandler = new UrlHandler(urlQueryConfig, browserHistory);
 
 const fixedFields = [
-  { id: 'lastWeek', label: 'Last Week' },
   { id: 'lastMonth', label: 'Last Month' },
+  { id: 'lastSixMonths', label: 'Last Six Months' },
   { id: 'lastYear', label: 'Last Year' },
 ];
 
@@ -633,17 +633,17 @@ class LocationPage extends PureComponent {
 
   renderFixedSummaryData() {
     const { summary = {} } = this.props;
-    const { lastWeek = {}, lastMonth = {}, lastYear = {} } = summary;
+    const { lastMonth = {}, lastSixMonths = {}, lastYear = {} } = summary;
 
     return (
       <div className="subsection">
         <header>
           <h3>Summary Data</h3>
         </header>
-        <h4>Last Week</h4>
-        <SummaryTable data={lastWeek.clientIspsData} bottomData={lastWeek.locationData} />
         <h4>Last Month</h4>
         <SummaryTable data={lastMonth.clientIspsData} bottomData={lastMonth.locationData} />
+        <h4>Last Six Months</h4>
+        <SummaryTable data={lastSixMonths.clientIspsData} bottomData={lastSixMonths.locationData} />
         <h4>Last Year</h4>
         <SummaryTable data={lastYear.clientIspsData} bottomData={lastYear.locationData} />
       </div>


### PR DESCRIPTION
We currently do not have "last 3 month" data either - as our pipeline hasnt been run in that long. 

So, i switched for now to showing last 6 months.

Also, fixes an issue with scatterplot that ensures data is present before attempting to display it.

<img width="1015" alt="screen shot 2016-10-19 at 12 16 34 pm" src="https://cloud.githubusercontent.com/assets/9369/19533944/b2440b52-95f6-11e6-8033-b71766b66148.png">
