### PR TITLE
Make hour charts share extent

### DIFF
--- a/src/components/CompareHourCharts/CompareHourCharts.jsx
+++ b/src/components/CompareHourCharts/CompareHourCharts.jsx
@@ -18,7 +18,9 @@ export default class CompareHourCharts extends PureComponent {
     breakdownBy: PropTypes.string,
     colors: PropTypes.object,
     combinedHourly: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
+    combinedHourlyExtents: PropTypes.object,
     facetItemHourly: PropTypes.array,
+    facetItemHourlyExtents: PropTypes.object,
     facetItemId: PropTypes.string,
     facetItemInfo: PropTypes.object,
     facetType: PropTypes.object,
@@ -32,7 +34,7 @@ export default class CompareHourCharts extends PureComponent {
     viewMetric: PropTypes.object,
   }
 
-  renderHourly(chartId, hourly, dataType) {
+  renderHourly(chartId, hourly, dataType, hourlyExtents) {
     const {
       highlightHourly,
       viewMetric,
@@ -44,25 +46,28 @@ export default class CompareHourCharts extends PureComponent {
       return null;
     }
 
-    const { status, data: hourlyData } = hourly;
+    const { status, data: hourlyData, wrangled } = hourly;
 
     if (!hourlyData || hourlyData.length === 0) {
       return null;
     }
     const color = colors[hourlyData.meta[dataType.idKey]];
+    // const hourlyExtents = hourlyData.extents;
 
     return (
       <StatusWrapper status={status}>
         <AutoWidth>
           <HourChartWithCounts
             color={color}
-            data={hourlyData.results}
+            countExtent={hourlyExtents.count}
+            dataByHour={wrangled.dataByHour}
+            overallData={wrangled.overallData}
             highlightHour={highlightHourly}
             id={chartId}
             onHighlightHour={onHighlightHourly}
             yAxisLabel={viewMetric.label}
             yAxisUnit={viewMetric.unit}
-            yExtent={hourlyData.extents[viewMetric.dataKey]}
+            yExtent={hourlyExtents[viewMetric.dataKey]}
             yFormatter={viewMetric.formatter}
             yKey={viewMetric.dataKey}
           />
@@ -82,6 +87,7 @@ export default class CompareHourCharts extends PureComponent {
   renderNoFilters(facetItemInfo) {
     const {
       facetItemHourly,
+      facetItemHourlyExtents,
       facetType,
     } = this.props;
 
@@ -92,13 +98,14 @@ export default class CompareHourCharts extends PureComponent {
     const chartId = `facet-hourly-${facetItemInfo.id}`;
     const hourly = facetItemHourly.find(hourly => hourly.id === facetItemInfo.id);
 
-    return this.renderHourly(chartId, hourly, facetType);
+    return this.renderHourly(chartId, hourly, facetType, facetItemHourlyExtents);
   }
 
   // if one filter has items, show the lines for those filter items in the chart
   renderSingleFilter(facetItemInfo, filterInfos, dataType) {
     const {
       combinedHourly,
+      combinedHourlyExtents,
     } = this.props;
 
     if (!combinedHourly) {
@@ -116,7 +123,7 @@ export default class CompareHourCharts extends PureComponent {
           return (
             <Col key={hourlyObject.id} md={6}>
               <h5>{info.label}</h5>
-              {this.renderHourly(chartId, hourlyObject, dataType)}
+              {this.renderHourly(chartId, hourlyObject, dataType, combinedHourlyExtents)}
             </Col>
           );
         })}

--- a/src/components/HourChart/HourChart.jsx
+++ b/src/components/HourChart/HourChart.jsx
@@ -12,7 +12,6 @@ import './HourChart.scss';
  */
 function visProps(props) {
   const {
-    data,
     color,
     forceZeroMin,
     height,
@@ -41,10 +40,9 @@ function visProps(props) {
   const yMax = 0;
 
 
-  // const data = []; console.warn('TODO data in HourChart');
-  // set up the domains based on extent. Use the prop if provided, otherwise calculate
+  // set up the domains based on extent.
   const xDomain = [0, 23];
-  let yDomain = yExtent || d3.extent(data, d => d[yKey]);
+  let yDomain = yExtent || [0, 1];
 
   // force 0 as the min in the yDomain if specified
   if (forceZeroMin) {

--- a/src/components/HourChart/HourChart.jsx
+++ b/src/components/HourChart/HourChart.jsx
@@ -12,8 +12,8 @@ import './HourChart.scss';
  */
 function visProps(props) {
   const {
-    color,
     data,
+    color,
     forceZeroMin,
     height,
     paddingLeft = 50,
@@ -40,6 +40,8 @@ function visProps(props) {
   const yMin = plotAreaHeight;
   const yMax = 0;
 
+
+  // const data = []; console.warn('TODO data in HourChart');
   // set up the domains based on extent. Use the prop if provided, otherwise calculate
   const xDomain = [0, 23];
   let yDomain = yExtent || d3.extent(data, d => d[yKey]);
@@ -72,7 +74,6 @@ function visProps(props) {
 
   return {
     binWidth,
-    data,
     height,
     plotAreaHeight,
     padding,
@@ -90,8 +91,6 @@ function visProps(props) {
  * Chart for showing data by hour
  *
  * @prop {String} color The color to render the chart in
- * @prop {Array} data The array of data points indexed by hour. Should be
- *   an array of length 24 of form [{ hour:Number(0..23), points: [{ yKey:Number }, ...]}, ...]
  * @prop {Boolean} forceZeroMin=true Whether the min y value should always be 0.
  * @prop {Number} height The height of the chart
  * @prop {Number} highlightHour The hour being highlighted in the chart
@@ -107,8 +106,6 @@ class HourChart extends PureComponent {
   static propTypes = {
     binWidth: PropTypes.number,
     color: PropTypes.string,
-    data: PropTypes.array,
-    dataByDate: PropTypes.object,
     dataByHour: PropTypes.array,
     forceZeroMin: PropTypes.bool,
     height: PropTypes.number,

--- a/src/components/HourChart/HourChartWithCounts.jsx
+++ b/src/components/HourChart/HourChartWithCounts.jsx
@@ -52,7 +52,6 @@ class HourChartWithCounts extends PureComponent {
     color: PropTypes.string,
     countExtent: PropTypes.array,
     dataByHour: PropTypes.array,
-    filteredData: PropTypes.array,
     forceZeroMin: PropTypes.bool,
     highlightHour: PropTypes.number,
     id: React.PropTypes.string,
@@ -80,7 +79,7 @@ class HourChartWithCounts extends PureComponent {
    */
   render() {
     const { id, width, color, highlightHour, onHighlightHour, dataByHour,
-      filteredData, padding, overallData, xScale, numBins, countExtent } = this.props;
+      padding, overallData, xScale, numBins, countExtent } = this.props;
 
     const hourHeight = 250;
     const countHeight = 80;
@@ -99,7 +98,6 @@ class HourChartWithCounts extends PureComponent {
             <HourChart
               {...this.props}
               color={color}
-              data={filteredData}
               dataByHour={dataByHour}
               overallData={overallData}
               id={undefined}

--- a/src/components/HourChart/HourChartWithCounts.jsx
+++ b/src/components/HourChart/HourChartWithCounts.jsx
@@ -2,76 +2,14 @@ import React, { PureComponent, PropTypes } from 'react';
 import d3 from 'd3';
 
 import { HourChart, CountChart } from '../../components';
-import { sum, average } from '../../utils/math';
 import addComputedProps from '../../hoc/addComputedProps';
 import { testThreshold } from '../../constants';
-
-
-/**
- * Filter the data and group it by hour and by date
- * @param {Object} props the component props
- * @return {Object} the prepared data { filteredData, dataByHour, dataByDate }
- */
-function prepareData(props) {
-  const { data, yKey } = props;
-
-  // filter so all data has a value for yKey
-  const filteredData = (data || []).filter(d => d[yKey] != null);
-
-  // produce the byHour array
-  const groupedByHour = d3.nest().key(d => d.hour).object(filteredData);
-
-  // use d3.range(24) instead of Object.keys to ensure we get an entry for each hour
-  const dataByHour = d3.range(24).map(hour => {
-    const hourPoints = groupedByHour[hour];
-    const count = sum(hourPoints, 'count') || 0;
-
-    return {
-      hour,
-      points: hourPoints || [],
-      count,
-      overall: average(hourPoints, yKey),
-    };
-  });
-
-  // produce the byDate array
-  const groupedByDate = d3.nest().key(d => d.date.format('YYYY-MM-DD')).object(filteredData);
-  const dataByDate = Object.keys(groupedByDate).reduce((byDate, date) => {
-    const datePoints = groupedByDate[date];
-    const count = sum(datePoints, 'count') || 0;
-
-    byDate[date] = {
-      date: datePoints[0].date,
-      points: datePoints,
-      count,
-    };
-
-    return byDate;
-  }, {});
-
-  // compute the overall data for an average line
-  const overallData = dataByHour.map(d => ({
-    [yKey]: d.overall,
-    hour: d.hour,
-    count: d.count,
-  })).filter(d => d[yKey] != null);
-
-  return {
-    filteredData,
-    dataByHour,
-    dataByDate,
-    overallData,
-  };
-}
-
 
 /**
  * Figure out what is needed for both charts
  */
 function visProps(props) {
   const { width } = props;
-
-  const preparedData = prepareData(props);
 
   const padding = {
     right: 50,
@@ -87,7 +25,6 @@ function visProps(props) {
   const numBins = 24; // one for each hour
 
   return {
-    ...preparedData,
     padding,
     numBins,
     xScale,
@@ -113,8 +50,7 @@ function visProps(props) {
 class HourChartWithCounts extends PureComponent {
   static propTypes = {
     color: PropTypes.string,
-    data: PropTypes.array,
-    dataByDate: PropTypes.object,
+    countExtent: PropTypes.array,
     dataByHour: PropTypes.array,
     filteredData: PropTypes.array,
     forceZeroMin: PropTypes.bool,
@@ -143,8 +79,8 @@ class HourChartWithCounts extends PureComponent {
    * @return {React.Component} The rendered container
    */
   render() {
-    const { id, width, color, highlightHour, onHighlightHour, dataByHour, dataByDate,
-      filteredData, padding, overallData, xScale, numBins } = this.props;
+    const { id, width, color, highlightHour, onHighlightHour, dataByHour,
+      filteredData, padding, overallData, xScale, numBins, countExtent } = this.props;
 
     const hourHeight = 250;
     const countHeight = 80;
@@ -165,7 +101,6 @@ class HourChartWithCounts extends PureComponent {
               color={color}
               data={filteredData}
               dataByHour={dataByHour}
-              dataByDate={dataByDate}
               overallData={overallData}
               id={undefined}
               inSvg
@@ -187,6 +122,7 @@ class HourChartWithCounts extends PureComponent {
               width={width}
               xKey="hour"
               xScale={xScale}
+              yExtent={countExtent}
             />
           </g>
         </svg>

--- a/src/containers/ComparePage/ComparePage.jsx
+++ b/src/containers/ComparePage/ComparePage.jsx
@@ -63,8 +63,10 @@ function mapStateToProps(state, propsWithUrl) {
     autoTimeAggregation: ComparePageSelectors.getAutoTimeAggregation(state, propsWithUrl),
     colors: ComparePageSelectors.getColors(state, propsWithUrl),
     combinedHourly: ComparePageSelectors.getCombinedHourly(state, propsWithUrl),
+    combinedHourlyExtents: ComparePageSelectors.getCombinedHourlyExtents(state, propsWithUrl),
     combinedTimeSeries: ComparePageSelectors.getCombinedTimeSeries(state, propsWithUrl),
     facetItemHourly: ComparePageSelectors.getFacetItemHourly(state, propsWithUrl),
+    facetItemHourlyExtents: ComparePageSelectors.getFacetItemHourlyExtents(state, propsWithUrl),
     facetItemInfos: ComparePageSelectors.getFacetItemInfos(state, propsWithUrl),
     facetItemTimeSeries: ComparePageSelectors.getFacetItemTimeSeries(state, propsWithUrl),
     facetType: ComparePageSelectors.getFacetType(state, propsWithUrl),
@@ -88,10 +90,12 @@ class ComparePage extends PureComponent {
     breakdownBy: PropTypes.string,
     colors: PropTypes.object,
     combinedHourly: PropTypes.object,
+    combinedHourlyExtents: PropTypes.object,
     combinedTimeSeries: PropTypes.object,
     dispatch: PropTypes.func,
     endDate: momentPropTypes.momentObj,
     facetItemHourly: PropTypes.array,
+    facetItemHourlyExtents: PropTypes.object,
     facetItemIds: PropTypes.array,
     facetItemInfos: PropTypes.array,
     facetItemTimeSeries: PropTypes.object,
@@ -672,9 +676,13 @@ class ComparePage extends PureComponent {
     const {
       breakdownBy,
       colors,
+      combinedHourly,
+      combinedHourlyExtents,
+      combinedTimeSeries,
       facetItemInfos,
       facetItemTimeSeries,
       facetItemHourly,
+      facetItemHourlyExtents,
       facetType,
       filter1Ids,
       filter1Infos,
@@ -684,8 +692,6 @@ class ComparePage extends PureComponent {
       highlightHourly,
       highlightTimeSeriesDate,
       highlightTimeSeriesLine,
-      combinedTimeSeries,
-      combinedHourly,
       viewMetric,
     } = this.props;
 
@@ -693,67 +699,78 @@ class ComparePage extends PureComponent {
     // if one filter has items, show the lines for those filter items in the chart
     // if both filters have items, group by `breakdownBy` filter and have the other filter items have lines in those charts
     return (
-      <Row>
-        <Col md={3}>
-          {this.renderBreakdownOptions()}
-        </Col>
-        <Col md={9}>
-          <div className="subsection">
-            <header>
-              <h3>Breakdown</h3>
-            </header>
-            {facetItemInfos.map((facetItemInfo) => (
-              <CompareTimeSeriesCharts
-                key={facetItemInfo.id}
-                breakdownBy={breakdownBy}
-                colors={colors}
-                combinedTimeSeries={combinedTimeSeries && combinedTimeSeries[facetItemInfo.id]}
-                facetItemId={facetItemInfo.id}
-                facetItemInfo={facetItemInfo}
-                facetItemTimeSeries={facetItemTimeSeries}
-                facetType={facetType}
-                filter1Ids={filter1Ids}
-                filter1Infos={filter1Infos}
-                filter2Ids={filter2Ids}
-                filter2Infos={filter2Infos}
-                filterTypes={filterTypes}
-                highlightTimeSeriesDate={highlightTimeSeriesDate}
-                highlightTimeSeriesLine={highlightTimeSeriesLine}
-                onHighlightTimeSeriesDate={this.onHighlightTimeSeriesDate}
-                onHighlightTimeSeriesLine={this.onHighlightTimeSeriesLine}
-                viewMetric={viewMetric}
-              />
-            ))}
-          </div>
-          <div className="subsection">
-            <header>
-              <h3>By Hour</h3>
-            </header>
-            <Row>
+      <div>
+        <Row>
+          <Col md={3}>
+            {this.renderBreakdownOptions()}
+          </Col>
+          <Col md={9}>
+            <div className="subsection">
+              <header>
+                <h3>Breakdown</h3>
+              </header>
               {facetItemInfos.map((facetItemInfo) => (
-                <CompareHourCharts
+                <CompareTimeSeriesCharts
                   key={facetItemInfo.id}
                   breakdownBy={breakdownBy}
                   colors={colors}
-                  combinedHourly={combinedHourly && combinedHourly[facetItemInfo.id]}
+                  combinedTimeSeries={combinedTimeSeries && combinedTimeSeries[facetItemInfo.id]}
                   facetItemId={facetItemInfo.id}
                   facetItemInfo={facetItemInfo}
-                  facetItemHourly={facetItemHourly}
+                  facetItemTimeSeries={facetItemTimeSeries}
                   facetType={facetType}
                   filter1Ids={filter1Ids}
                   filter1Infos={filter1Infos}
                   filter2Ids={filter2Ids}
                   filter2Infos={filter2Infos}
                   filterTypes={filterTypes}
-                  highlightHourly={highlightHourly}
-                  onHighlightHourly={this.onHighlightHourly}
+                  highlightTimeSeriesDate={highlightTimeSeriesDate}
+                  highlightTimeSeriesLine={highlightTimeSeriesLine}
+                  onHighlightTimeSeriesDate={this.onHighlightTimeSeriesDate}
+                  onHighlightTimeSeriesLine={this.onHighlightTimeSeriesLine}
                   viewMetric={viewMetric}
                 />
-            ))}
-            </Row>
-          </div>
-        </Col>
-      </Row>
+              ))}
+            </div>
+          </Col>
+        </Row>
+        <Row>
+          <Col md={3}>
+            {this.renderMetricSelector()}
+          </Col>
+          <Col md={9}>
+            <div className="subsection">
+              <header>
+                <h3>By Hour</h3>
+              </header>
+              <Row>
+                {facetItemInfos.map((facetItemInfo) => (
+                  <CompareHourCharts
+                    key={facetItemInfo.id}
+                    breakdownBy={breakdownBy}
+                    colors={colors}
+                    combinedHourly={combinedHourly && combinedHourly[facetItemInfo.id]}
+                    combinedHourlyExtents={combinedHourlyExtents}
+                    facetItemId={facetItemInfo.id}
+                    facetItemInfo={facetItemInfo}
+                    facetItemHourly={facetItemHourly}
+                    facetItemHourlyExtents={facetItemHourlyExtents}
+                    facetType={facetType}
+                    filter1Ids={filter1Ids}
+                    filter1Infos={filter1Infos}
+                    filter2Ids={filter2Ids}
+                    filter2Infos={filter2Infos}
+                    filterTypes={filterTypes}
+                    highlightHourly={highlightHourly}
+                    onHighlightHourly={this.onHighlightHourly}
+                    viewMetric={viewMetric}
+                  />
+              ))}
+              </Row>
+            </div>
+          </Col>
+        </Row>
+      </div>
     );
   }
 

--- a/src/containers/LocationPage/LocationPage.jsx
+++ b/src/containers/LocationPage/LocationPage.jsx
@@ -545,7 +545,7 @@ class LocationPage extends PureComponent {
       return null;
     }
 
-    const { data: hourlyData, status: hourlyStatus, wrangled = {} } = hourly;
+    const { data: hourlyData, status: hourlyStatus, wrangled } = hourly;
 
     if (!hourlyData || !hourlyData.meta) {
       return null;
@@ -564,7 +564,6 @@ class LocationPage extends PureComponent {
                 countExtent={hourlyExtents.count}
                 dataByHour={wrangled.dataByHour}
                 overallData={wrangled.overallData}
-                filteredData={wrangled.filteredData}
                 highlightHour={highlightHourly}
                 id={chartId}
                 onHighlightHour={this.onHighlightHourly}

--- a/src/containers/LocationPage/LocationPage.jsx
+++ b/src/containers/LocationPage/LocationPage.jsx
@@ -76,6 +76,7 @@ function mapStateToProps(state, propsWithUrl) {
     highlightHourly: LocationPageSelectors.getHighlightHourly(state, propsWithUrl),
     highlightTimeSeriesDate: LocationPageSelectors.getHighlightTimeSeriesDate(state, propsWithUrl),
     highlightTimeSeriesLine: LocationPageSelectors.getHighlightTimeSeriesLine(state, propsWithUrl),
+    hourlyExtents: LocationPageSelectors.getHourlyExtents(state, propsWithUrl),
     locationInfo: LocationsSelectors.getLocationInfo(state, propsWithUrl),
     locationAndClientIspTimeSeries: LocationPageSelectors.getLocationAndClientIspTimeSeries(state, propsWithUrl),
     locationHourly: LocationPageSelectors.getLocationHourly(state, propsWithUrl),
@@ -104,6 +105,7 @@ class LocationPage extends PureComponent {
     highlightHourly: PropTypes.number,
     highlightTimeSeriesDate: PropTypes.object,
     highlightTimeSeriesLine: PropTypes.object,
+    hourlyExtents: PropTypes.object,
     location: PropTypes.object, // route location
     locationAndClientIspTimeSeries: PropTypes.array,
     locationHourly: PropTypes.object,
@@ -526,14 +528,14 @@ class LocationPage extends PureComponent {
   }
 
   renderHourChart(hourly, color) {
-    const { highlightHourly, locationId, viewMetric } = this.props;
+    const { highlightHourly, hourlyExtents, locationId, viewMetric } = this.props;
     const extentKey = this.extentKey(viewMetric);
 
     if (!hourly) {
       return null;
     }
 
-    const { data: hourlyData, status: hourlyStatus } = hourly;
+    const { data: hourlyData, status: hourlyStatus, wrangled = {} } = hourly;
 
     if (!hourlyData || !hourlyData.meta) {
       return null;
@@ -549,13 +551,16 @@ class LocationPage extends PureComponent {
             <AutoWidth>
               <HourChartWithCounts
                 color={color}
-                data={hourlyData.results}
+                countExtent={hourlyExtents.count}
+                dataByHour={wrangled.dataByHour}
+                overallData={wrangled.overallData}
+                filteredData={wrangled.filteredData}
                 highlightHour={highlightHourly}
                 id={chartId}
                 onHighlightHour={this.onHighlightHourly}
                 yAxisLabel={viewMetric.label}
                 yAxisUnit={viewMetric.unit}
-                yExtent={hourlyData.extents[extentKey]}
+                yExtent={hourlyExtents[extentKey]}
                 yFormatter={viewMetric.formatter}
                 yKey={viewMetric.dataKey}
               />

--- a/src/containers/LocationPage/LocationPage.jsx
+++ b/src/containers/LocationPage/LocationPage.jsx
@@ -529,7 +529,7 @@ class LocationPage extends PureComponent {
 
   renderHourChart(hourly, color) {
     const { highlightHourly, hourlyExtents, locationId, viewMetric } = this.props;
-    const extentKey = this.extentKey(viewMetric);
+    const extentKey = viewMetric.dataKey;
 
     if (!hourly) {
       return null;

--- a/src/utils/array.js
+++ b/src/utils/array.js
@@ -18,18 +18,25 @@ import binarySearch from 'binary-search';
  * @param {Array} outerArray An array of arrays or objects
  * @param {Function} [valueAccessor] How to read a value in the array (defaults to identity)
  * @param {Function} [arrayAccessor] How to read an inner array (defaults to identity)
+ * @param {Number} [quantile] If provided, limits the max to this percentile value.
  * @return {Array} the extent
  */
-export function multiExtent(outerArray, valueAccessor = d => d, arrayAccessor = d => d) {
+export function multiExtent(outerArray, valueAccessor = d => d, arrayAccessor = d => d, quantile) {
   if (!outerArray || !outerArray.length) {
     return undefined;
   }
 
+  // flatten the arrays into one big array
+  const combined = outerArray.reduce((carry, inner) => carry.concat(arrayAccessor(inner)), []);
 
-  const innerExtents = outerArray.map(inner => arrayAccessor(inner))
-    .map(inner => d3.extent(inner, valueAccessor));
+  const extent = d3.extent(combined, valueAccessor);
 
-  const extent = [d3.min(innerExtents, d => d[0]), d3.max(innerExtents, d => d[1])];
+  // limit to quantile if passed in
+  if (quantile != null) {
+    combined.sort((a, b) => valueAccessor(a) - valueAccessor(b));
+    extent[1] = d3.quantile(combined, quantile, valueAccessor);
+  }
+
   return extent;
 }
 

--- a/src/utils/computeHourlyExtents.js
+++ b/src/utils/computeHourlyExtents.js
@@ -1,0 +1,36 @@
+import { multiExtent } from './array';
+
+/**
+ * Helper to compute a shared extent for multiple hourly data items
+ * Expects hourlyItems of form [{ wrangled }, ...]
+ *
+ * @return {Object} extents { dataKey: [], count: [] }
+ */
+export default function computeHourlyExtents(hourlyItems, dataKey) {
+  const extents = {};
+
+  if (!hourlyItems) {
+    return extents;
+  }
+
+  const filtered = hourlyItems
+    .map(d => d.wrangled)
+    .filter(d => d != null);
+
+  if (filtered.length) {
+    // get the extents filtered to the 95% percentile while making sure overallData fits
+    const extent = multiExtent(filtered, d => d[dataKey], d => d.filteredData, 0.95);
+
+    // check the overallData extent
+    const overallExtent = multiExtent(filtered, d => d[dataKey], d => d.overallData);
+    extent[0] = Math.min(extent[0], overallExtent[0]);
+    extent[1] = Math.max(extent[1], overallExtent[1]);
+
+    extents[dataKey] = extent;
+
+    // get the count extent
+    extents.count = multiExtent(filtered, d => d.count, d => d.overallData);
+  }
+
+  return extents;
+}

--- a/src/utils/tests/array-test.js
+++ b/src/utils/tests/array-test.js
@@ -40,6 +40,16 @@ describe('utils', () => {
         const result = multiExtent(null);
         expect(result).to.be.undefined;
       });
+
+      it('produces the correct value with quantile limit', () => {
+        const outerArray = [
+          [1, 2, 3],
+          [0, 2, 1],
+          [2, 5, 9],
+        ];
+        const result = multiExtent(outerArray, undefined, undefined, 0.6);
+        expect(result).to.deep.equal([0, 2]);
+      });
     });
 
     describe('findClosestSorted', () => {

--- a/src/utils/wrangleHourly.js
+++ b/src/utils/wrangleHourly.js
@@ -1,0 +1,50 @@
+import d3 from '../d3';
+import { sum, average } from './math';
+
+/**
+ * Filter the data and group it by hour and by date
+ * @param {Object} hourly the hourly data object { results }
+ * @param {Object} viewMetric the active view metric to wrangle the data for
+ * @return {Object} the prepared data { filteredData, dataByHour, overallData }
+ */
+export default function wrangleHourly(hourly, viewMetric) {
+  if (!hourly) {
+    return undefined;
+  }
+
+  const data = hourly.results;
+  const yKey = viewMetric.dataKey;
+
+  // filter so all data has a value for yKey
+  const filteredData = (data || []).filter(d => d[yKey] != null);
+
+  // produce the byHour array
+  const groupedByHour = d3.nest().key(d => d.hour).object(filteredData);
+
+  // use d3.range(24) instead of Object.keys to ensure we get an entry for each hour
+  const dataByHour = d3.range(24).map(hour => {
+    const hourPoints = groupedByHour[hour];
+    const count = sum(hourPoints, 'count') || 0;
+
+    return {
+      hour,
+      points: hourPoints || [],
+      count,
+      overall: average(hourPoints, yKey),
+    };
+  });
+
+  // compute the overall data for an average line
+  const overallData = dataByHour.map(d => ({
+    [yKey]: d.overall,
+    hour: d.hour,
+    count: d.count,
+  })).filter(d => d[yKey] != null);
+
+
+  return {
+    filteredData,
+    overallData,
+    dataByHour,
+  };
+}


### PR DESCRIPTION
Hour charts on location and compare page now share the same y-axis extents for both the chart and count histograms. Resolve #165