### PR TITLE
More tooltips

### DIFF
--- a/src/components/CompareInputPanel/CompareInputPanel.jsx
+++ b/src/components/CompareInputPanel/CompareInputPanel.jsx
@@ -5,6 +5,7 @@ import Col from 'react-bootstrap/lib/Col';
 import {
   FilterSuggestions,
   SearchSelect,
+  HelpTip,
 } from '../../components';
 
 import './CompareInputPanel.scss';
@@ -83,7 +84,9 @@ export default class CompareLocationsInput extends PureComponent {
 
     return (
       <div>
-        <h4>Filter by Transit ISP</h4>
+        <h4>
+          Filter by Transit ISP <HelpTip id="transit-compare-tip" />
+        </h4>
         <p>Select one or more Transit ISPs to filter the measurements by.</p>
         <SearchSelect
           type="transitIsp"

--- a/src/components/HelpTip/HelpTip.jsx
+++ b/src/components/HelpTip/HelpTip.jsx
@@ -3,6 +3,8 @@ import ReactTooltip from 'react-tooltip';
 
 import { Icon } from '../../components';
 
+import { helpTipContent } from '../../constants';
+
 import './HelpTip.scss';
 
 /**
@@ -21,7 +23,11 @@ export default class HelpTip extends PureComponent {
   }
 
   render() {
-    const { id, style, content, place } = this.props;
+    const { id, style, place } = this.props;
+    let { content } = this.props;
+    if (!content) {
+      content = helpTipContent[id];
+    }
     const offset = { top: -5, left: -8 };
 
     return (

--- a/src/components/HelpTip/HelpTip.scss
+++ b/src/components/HelpTip/HelpTip.scss
@@ -13,4 +13,8 @@
     }
   }
 
+  .__react_component_tooltip {
+    max-width: 300px;
+  }
+
 }

--- a/src/components/MetricSelector/MetricSelector.jsx
+++ b/src/components/MetricSelector/MetricSelector.jsx
@@ -19,7 +19,7 @@ export default class MetricSelector extends PureComponent {
 
     return (
       <div className="metric-selector">
-        <h5>Metric <HelpTip content="Specify which metric to visualize." id="metric-tip" />
+        <h5>Metric <HelpTip id="metric-tip" />
         </h5>
         <SelectableList items={metrics} active={active} onChange={onChange} />
       </div>

--- a/src/components/TimeAggregationSelector/TimeAggregationSelector.jsx
+++ b/src/components/TimeAggregationSelector/TimeAggregationSelector.jsx
@@ -19,7 +19,7 @@ export default class TimeAggregationSelector extends PureComponent {
 
     return (
       <div className="time-aggregation-selector">
-        <h5>Time Aggregation <HelpTip id="time-agg-tip" content="Specify how the data should be binned by time." /></h5>
+        <h5>Time Aggregation <HelpTip id="time-agg-tip" /></h5>
         <SelectableList items={timeAggregations} active={active} onChange={onChange} />
       </div>
     );

--- a/src/constants.js
+++ b/src/constants.js
@@ -23,7 +23,7 @@ export const metrics = [
     countBinKey: 'download_speed_mbps_bins',
     percentBinKey: 'download_speed_mbps_percent_bins',
     formatter: d3.format('.1f'),
-    description: 'Median download speed for provided time range<br> at the selected time aggregation.',
+    description: 'Median download speed for provided time range at the selected time aggregation.',
   },
   {
     value: 'upload',
@@ -33,7 +33,7 @@ export const metrics = [
     countBinKey: 'upload_speed_mbps_bins',
     percentBinKey: 'upload_speed_mbps_percent_bins',
     formatter: d3.format('.1f'),
-    description: 'Median upload speed for provided time range<br> at the selected time aggregation.',
+    description: 'Median upload speed for provided time range at the selected time aggregation.',
   },
   {
     value: 'rtt',

--- a/src/constants.js
+++ b/src/constants.js
@@ -88,4 +88,13 @@ export const ispLabelReplacements = [
 export const helpTipContent = {
   'transit-compare-tip': 'Transit ISPs serve to support the backbone of the Internet. Client ISPs send traffic to Transit ISPs to be routed worldwide. MLab servers are located within Transit ISP switching stations.',
   'client-isp-tip': 'Add or remove ISPs to compare. ISP names come from volunteer process of mapping ASNs to names and so are at times confusingly inconsistent with actual ISP names. Multiple ASNs can be owned by a single ISP and so near duplicate names can appear.',
+  'metric-tip': 'Specify which metric to visualize.',
+  'time-agg-tip': 'Specify how the data should be binned by time.',
+  'regional-tip': 'Show or hide baseline value for the location you are viewing.',
+  'compare-metrics-tip': 'Shows all metrics for each ISP selected along with location data for reference.',
+  'hour-metric-tip': 'Aggregates metric for each hour over time range. Line indicates Average value for each hour.',
+  'fixed-time-tip': 'Charts below are based on fixed time data instead of using the selected time from above.',
+  'fixed-compare-metrics-tip': 'Compare one metric against another over a set of fixed time ranges.',
+  'fixed-metric-tip': 'Shows a histogram of metric data broken up into evenly spaced bins. Each bar shows percent of total tests that fall into that bin.',
+  'facet-tip': 'Toggle what to aggregate data by.',
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -84,3 +84,8 @@ export const ispLabelReplacements = [
   { find: /^(http:\/\/)/, replace: '' }, // prefixes
   { find: /\s*(,|\.)\s*$/, replace: '' }, //ending punctuation
 ];
+
+export const helpTipContent = {
+  'transit-compare-tip': 'Transit ISPs serve to support the backbone of the Internet. Client ISPs send traffic to Transit ISPs to be routed worldwide. MLab servers are located within Transit ISP switching stations.',
+  'client-isp-tip': 'Add or remove ISPs to compare. ISP names come from volunteer process of mapping ASNs to names and so are at times confusingly inconsistent with actual ISP names. Multiple ASNs can be owned by a single ISP and so near duplicate names can appear.',
+};

--- a/src/containers/ComparePage/ComparePage.jsx
+++ b/src/containers/ComparePage/ComparePage.jsx
@@ -520,7 +520,7 @@ class ComparePage extends PureComponent {
 
     return (
       <div className="facet-by-selector">
-        <h5>Facet By <HelpTip content="Toggle what to aggregate data by." id="facet-tip" />
+        <h5>Facet By <HelpTip id="facet-tip" />
         </h5>
         <SelectableList items={facetTypes} active={facetType.value} onChange={this.onFacetTypeChange} />
       </div>

--- a/src/containers/LocationPage/LocationPage.jsx
+++ b/src/containers/LocationPage/LocationPage.jsx
@@ -440,7 +440,7 @@ class LocationPage extends PureComponent {
                   onChange={this.onShowRegionalValuesChange}
                 />
                 {' Show Regional Values '}
-                <HelpTip content="Show or hide baseline value for the location you are viewing." id="regional-tip" />
+                <HelpTip id="regional-tip" />
               </label>
             </div>
           </li>
@@ -498,7 +498,7 @@ class LocationPage extends PureComponent {
     return (
       <div className="subsection">
         <header>
-          <h3>Compare Metrics <HelpTip content="Shows all metrics for each ISP selected along with location data for reference." id="compare-metrics-tip" />
+          <h3>Compare Metrics <HelpTip id="compare-metrics-tip" />
           </h3>
         </header>
         <StatusWrapper status={timeSeriesStatus}>
@@ -522,7 +522,7 @@ class LocationPage extends PureComponent {
     return (
       <div className="subsection">
         <header>
-          <h3>{`${viewMetric.label} by Hour`} <HelpTip content="Aggregates metric for each hour over time range. Line indicates Average value for each hour." id="hour-metric-tip" /></h3>
+          <h3>{`${viewMetric.label} by Hour`} <HelpTip id="hour-metric-tip" /></h3>
         </header>
         <Row>
           {this.renderHourChart(locationHourly)}
@@ -589,7 +589,7 @@ class LocationPage extends PureComponent {
         <Row>
           <Col md={12}>
             <header>
-              <h2>Compare Fixed Time Frame <HelpTip content="Charts below are based on fixed time data instead of using the selected time from above." id="fixed-time-tip" /></h2>
+              <h2>Compare Fixed Time Frame <HelpTip id="fixed-time-tip" /></h2>
             </header>
           </Col>
         </Row>
@@ -619,7 +619,7 @@ class LocationPage extends PureComponent {
     return (
       <div className="subsection">
         <header>
-          <h3>Compare Metrics <HelpTip content="Compare one metric against another over a set of fixed time ranges." id="fixed-compare-metrics-tip" />
+          <h3>Compare Metrics <HelpTip id="fixed-compare-metrics-tip" />
           </h3>
         </header>
         <ScatterGroup
@@ -637,7 +637,7 @@ class LocationPage extends PureComponent {
     return (
       <div className="subsection">
         <header>
-          <h3>Distribution of {viewMetric.label} <HelpTip content="Shows a histogram of metric data broken up into evenly spaced bins. Each bar shows percent of total tests that fall into that bin." id="fixed-metric-tip" />
+          <h3>Distribution of {viewMetric.label} <HelpTip id="fixed-metric-tip" />
           </h3>
         </header>
         <HistoGroup

--- a/src/containers/LocationPage/LocationPage.jsx
+++ b/src/containers/LocationPage/LocationPage.jsx
@@ -383,7 +383,7 @@ class LocationPage extends PureComponent {
 
     return (
       <div className="client-isp-selector">
-        <h5>Client ISPs <HelpTip id="client-isp-tip" content="Add or remove ISPs to compare. ISP names come from volunteer process of mapping ASNs to names and so are at times confusingly inconsistent with actual ISP names. Multiple ASNs can be owned by a single ISP and so near duplicate names can appear." /></h5>
+        <h5>Client ISPs <HelpTip id="client-isp-tip" /></h5>
         <IspSelect
           isps={topClientIsps}
           selected={selectedClientIspInfo}

--- a/src/containers/LocationPage/LocationPage.jsx
+++ b/src/containers/LocationPage/LocationPage.jsx
@@ -383,7 +383,7 @@ class LocationPage extends PureComponent {
 
     return (
       <div className="client-isp-selector">
-        <h5>Client ISPs</h5>
+        <h5>Client ISPs <HelpTip id="client-isp-tip" content="Add or remove ISPs to compare. ISP names come from volunteer process of mapping ASNs to names and so are at times confusingly inconsistent with actual ISP names. Multiple ASNs can be owned by a single ISP and so near duplicate names can appear." /></h5>
         <IspSelect
           isps={topClientIsps}
           selected={selectedClientIspInfo}


### PR DESCRIPTION
Start to adress #89 with tooltips.

<img width="438" alt="screen shot 2016-10-20 at 2 48 37 pm" src="https://cloud.githubusercontent.com/assets/9369/19579233/5bfb7c74-96d4-11e6-9e9d-ab2fc3a166a8.png">


Also, moved some content of tooltips to `constants`. What do you think about this approach @pbeshai ? if its fine, i'll convert the other tooltips and all text will be in one place. 

Also makes tooltips fixed width. 