### PR TITLE
Update breakdown area of compare page

### DIFF
--- a/src/components/CompareHourCharts/CompareHourCharts.jsx
+++ b/src/components/CompareHourCharts/CompareHourCharts.jsx
@@ -52,7 +52,6 @@ export default class CompareHourCharts extends PureComponent {
       return null;
     }
     const color = colors[hourlyData.meta[dataType.idKey]];
-    // const hourlyExtents = hourlyData.extents;
 
     return (
       <StatusWrapper status={status}>
@@ -135,6 +134,7 @@ export default class CompareHourCharts extends PureComponent {
   renderBothFilters(facetItemInfo, filter1Infos, filter2Infos) {
     const {
       combinedHourly,
+      combinedHourlyExtents,
       breakdownBy,
       filterTypes,
     } = this.props;
@@ -166,7 +166,7 @@ export default class CompareHourCharts extends PureComponent {
                   return (
                     <Col key={`${breakdownId}-${filterId}`} md={6}>
                       <h6>{filterInfo.label}</h6>
-                      {this.renderHourly(chartId, hourObject, dataType)}
+                      {this.renderHourly(chartId, hourObject, dataType, combinedHourlyExtents)}
                     </Col>
                   );
                 })}

--- a/src/containers/ComparePage/ComparePage.jsx
+++ b/src/containers/ComparePage/ComparePage.jsx
@@ -672,6 +672,25 @@ class ComparePage extends PureComponent {
     return null;
   }
 
+  getBreakdownLabel() {
+    const { breakdownBy, facetType, filterTypes, filter1Ids, filter2Ids } = this.props;
+    let label = `Breakdown by ${facetType.label}s`;
+
+    if (filter1Ids.length && filter2Ids.length) {
+      if (breakdownBy === 'filter1') {
+        label = `${filterTypes[1].label}s by ${facetType.label}s and ${filterTypes[0].label}s`;
+      } else {
+        label = `${filterTypes[0].label}s by ${facetType.label}s and ${filterTypes[1].label}s`;
+      }
+    } else if (filter1Ids.length) {
+      label = `${filterTypes[0].label}s by ${facetType.label}s`;
+    } else if (filter2Ids.length) {
+      label = `${filterTypes[1].label}s by ${facetType.label}s`;
+    }
+
+    return label;
+  }
+
   renderBreakdown() {
     const {
       breakdownBy,
@@ -699,6 +718,7 @@ class ComparePage extends PureComponent {
     // if one filter has items, show the lines for those filter items in the chart
     // if both filters have items, group by `breakdownBy` filter and have the other filter items have lines in those charts
     const renderBreakdownTimeSeries = filter1Ids.length || filter2Ids.length;
+    const breakdownLabel = this.getBreakdownLabel();
 
     return (
       <div>
@@ -710,7 +730,7 @@ class ComparePage extends PureComponent {
             <Col md={9}>
               <div className="subsection">
                 <header>
-                  <h3>Breakdown</h3>
+                  <h3>{breakdownLabel}</h3>
                 </header>
                 {facetItemInfos.map((facetItemInfo) => (
                   <CompareTimeSeriesCharts

--- a/src/containers/ComparePage/ComparePage.jsx
+++ b/src/containers/ComparePage/ComparePage.jsx
@@ -698,42 +698,46 @@ class ComparePage extends PureComponent {
     // if filters are empty, show the facet item line in the chart
     // if one filter has items, show the lines for those filter items in the chart
     // if both filters have items, group by `breakdownBy` filter and have the other filter items have lines in those charts
+    const renderBreakdownTimeSeries = filter1Ids.length || filter2Ids.length;
+
     return (
       <div>
-        <Row>
-          <Col md={3}>
-            {this.renderBreakdownOptions()}
-          </Col>
-          <Col md={9}>
-            <div className="subsection">
-              <header>
-                <h3>Breakdown</h3>
-              </header>
-              {facetItemInfos.map((facetItemInfo) => (
-                <CompareTimeSeriesCharts
-                  key={facetItemInfo.id}
-                  breakdownBy={breakdownBy}
-                  colors={colors}
-                  combinedTimeSeries={combinedTimeSeries && combinedTimeSeries[facetItemInfo.id]}
-                  facetItemId={facetItemInfo.id}
-                  facetItemInfo={facetItemInfo}
-                  facetItemTimeSeries={facetItemTimeSeries}
-                  facetType={facetType}
-                  filter1Ids={filter1Ids}
-                  filter1Infos={filter1Infos}
-                  filter2Ids={filter2Ids}
-                  filter2Infos={filter2Infos}
-                  filterTypes={filterTypes}
-                  highlightTimeSeriesDate={highlightTimeSeriesDate}
-                  highlightTimeSeriesLine={highlightTimeSeriesLine}
-                  onHighlightTimeSeriesDate={this.onHighlightTimeSeriesDate}
-                  onHighlightTimeSeriesLine={this.onHighlightTimeSeriesLine}
-                  viewMetric={viewMetric}
-                />
-              ))}
-            </div>
-          </Col>
-        </Row>
+        {renderBreakdownTimeSeries ? (
+          <Row>
+            <Col md={3}>
+              {this.renderBreakdownOptions()}
+            </Col>
+            <Col md={9}>
+              <div className="subsection">
+                <header>
+                  <h3>Breakdown</h3>
+                </header>
+                {facetItemInfos.map((facetItemInfo) => (
+                  <CompareTimeSeriesCharts
+                    key={facetItemInfo.id}
+                    breakdownBy={breakdownBy}
+                    colors={colors}
+                    combinedTimeSeries={combinedTimeSeries && combinedTimeSeries[facetItemInfo.id]}
+                    facetItemId={facetItemInfo.id}
+                    facetItemInfo={facetItemInfo}
+                    facetItemTimeSeries={facetItemTimeSeries}
+                    facetType={facetType}
+                    filter1Ids={filter1Ids}
+                    filter1Infos={filter1Infos}
+                    filter2Ids={filter2Ids}
+                    filter2Infos={filter2Infos}
+                    filterTypes={filterTypes}
+                    highlightTimeSeriesDate={highlightTimeSeriesDate}
+                    highlightTimeSeriesLine={highlightTimeSeriesLine}
+                    onHighlightTimeSeriesDate={this.onHighlightTimeSeriesDate}
+                    onHighlightTimeSeriesLine={this.onHighlightTimeSeriesLine}
+                    viewMetric={viewMetric}
+                  />
+                ))}
+              </div>
+            </Col>
+          </Row>
+        ) : null}
         <Row>
           <Col md={3}>
             {this.renderMetricSelector()}
@@ -741,7 +745,7 @@ class ComparePage extends PureComponent {
           <Col md={9}>
             <div className="subsection">
               <header>
-                <h3>By Hour</h3>
+                <h3>{`${viewMetric.label} by Hour`}</h3>
               </header>
               <Row>
                 {facetItemInfos.map((facetItemInfo) => (

--- a/src/redux/comparePage/selectors.js
+++ b/src/redux/comparePage/selectors.js
@@ -661,12 +661,31 @@ export const getCombinedHourly = createSelector(
 );
 
 /**
+ * Helper to merge the possibly two levels of nesting of combined hourly
+ * into a flat array
+ */
+function flattenCombinedHourly(combinedHourly) {
+  if (!combinedHourly) {
+    return [];
+  }
+
+  let values = d3.values(combinedHourly);
+  if (values.length && !Array.isArray(values[0])) {
+    // run one level deeper
+    values = d3.values(combinedHourly).reduce((carry, d) => carry.concat(d3.values(d)), []);
+  }
+
+  const results = d3.merge(values);
+  return results;
+}
+
+/**
  * Get shared extents of all the hourly data
  */
 export const getCombinedHourlyExtents = createSelector(
   getCombinedHourly, getViewMetric,
   (combinedHourly, viewMetric) =>
-    computeHourlyExtents(d3.merge(d3.values(combinedHourly)), viewMetric.dataKey));
+    computeHourlyExtents(flattenCombinedHourly(combinedHourly), viewMetric.dataKey));
 
 /**
  * Selector to get the colors given all the selected ISPs and locations


### PR DESCRIPTION
- Removes breakdown when no filters selected since it is redundant. Resolves #210.
- Fixes a bug when both filters are active that caused hour charts not to render
- Make the breakdown title based on the configuration

#### Breakdown header examples

facet Location, filter client ISP
![image](https://cloud.githubusercontent.com/assets/793847/19580019/8c08f2e4-96f1-11e6-8e62-be0d1d7fbe64.png)

facet location, filter both
![image](https://cloud.githubusercontent.com/assets/793847/19580022/94ae45fc-96f1-11e6-958e-4ce41f7912f7.png)

![image](https://cloud.githubusercontent.com/assets/793847/19580027/a00e35e2-96f1-11e6-98b4-25fb3b9e0992.png)
