### PR TITLE
Map updates

### DIFF
--- a/src/components/WorldMap/WorldMap.jsx
+++ b/src/components/WorldMap/WorldMap.jsx
@@ -32,11 +32,16 @@ function dataToGeoJson(data) {
   return { type: 'FeatureCollection', features };
 }
 
+/**
+ * Extract server features from the geoData. Only add one server
+ * for each unique lat,lng position.
+ * @return {Object[]} The server features
+ */
 function serversToFeatures(geoData) {
   const serversById = {};
   const serverId = (lat, lng) => `${lat}_${lng}`;
 
-  geoData.features.forEach((d, i) => {
+  geoData.features.forEach((d) => {
     const { serverPos } = d.properties;
     const id = serverId(serverPos[0], serverPos[1]);
 
@@ -75,8 +80,6 @@ function transitionLine(path) {
     .duration(d => durationScale(d.properties.data.download_speed_mbps))
     .ease(d3.easeQuadOut)
     .attrTween('stroke-dasharray', tweenDash)
-    // this should remove dashing on transition end
-    // .on('end', function endDashTransition() { d3.select(this).attr('stroke-dasharray', 'none'); })
     .style('stroke-dashoffset', '0%')
     .transition()
     .duration(500)
@@ -108,7 +111,7 @@ function visProps(props) {
     .range([2, 18])
     .clamp(true);
 
-  const colors = ['#fd150b', '#ff8314', '#ffc33b', '#f3f5e7', '#6fb7d0', '#2970ac'].reverse();
+  const colors = ['#2970ac', '#6fb7d0', '#f3f5e7', '#ffc33b', '#ff8314', '#fd150b'];
 
   const colorScale = d3.scaleLinear()
     .range(colors)

--- a/src/components/WorldMap/WorldMap.jsx
+++ b/src/components/WorldMap/WorldMap.jsx
@@ -153,6 +153,10 @@ class WorldMap extends PureComponent {
     this.setup();
   }
 
+  componentWillUnmount() {
+    this.timer.stop();
+  }
+
   /*
    * Convert d3 / geojson point to leaflet point
    */

--- a/src/components/WorldMap/WorldMap.jsx
+++ b/src/components/WorldMap/WorldMap.jsx
@@ -82,7 +82,7 @@ function transitionLine(path) {
     .attrTween('stroke-dasharray', tweenDash)
     .style('stroke-dashoffset', '0%')
     .transition()
-    .duration(500)
+    .duration(d => durationScale(d.properties.data.download_speed_mbps) / 2)
     // make the line disappear the way it came
     .styleTween('stroke-dashoffset', function dashoffsetTween() {
       const l = this.getTotalLength();

--- a/src/components/WorldMap/WorldMap.jsx
+++ b/src/components/WorldMap/WorldMap.jsx
@@ -32,6 +32,22 @@ function dataToGeoJson(data) {
   return { type: 'FeatureCollection', features };
 }
 
+function serversToFeatures(geoData) {
+  const serversById = {};
+  const serverId = (lat, lng) => `${lat}_${lng}`;
+
+  geoData.features.forEach((d, i) => {
+    const { serverPos } = d.properties;
+    const id = serverId(serverPos[0], serverPos[1]);
+
+    if (!serversById[id]) {
+      serversById[id] = pointToFeature(id, serverPos);
+    }
+  });
+
+  return d3.values(serversById);
+}
+
 /*
  * Dashed line interpolation hack from
  * https://bl.ocks.org/mbostock/5649592
@@ -85,7 +101,7 @@ function visProps(props) {
   }
 
   const geoData = dataToGeoJson(data);
-  const servers = geoData.features.map((d, i) => pointToFeature(i, d.properties.serverPos));
+  const servers = serversToFeatures(geoData);
 
   const rScale = d3.scaleSqrt()
     .domain([0, 100])

--- a/src/components/WorldMap/WorldMap.jsx
+++ b/src/components/WorldMap/WorldMap.jsx
@@ -239,6 +239,10 @@ class WorldMap extends PureComponent {
 
     this.svg = d3.select(this.map.getPanes().overlayPane).append('svg');
     this.g = this.svg.append('g').attr('class', 'leaflet-zoom-hide');
+    this.g.append('g').attr('class', 'clients');
+    this.g.append('g').attr('class', 'client-server-lines');
+    this.g.append('g').attr('class', 'servers');
+    this.g.append('g').attr('class', 'blasts');
 
     this.setupDefs(this.svg);
 
@@ -254,6 +258,16 @@ class WorldMap extends PureComponent {
 
     // update visual
     this.timer = d3.interval(this.updateViewable, updateFrequency);
+  }
+
+  /**
+   * Callback for when the map is zoomed
+   */
+  resetView() {
+    // remove blasts when resetting view since they do not exist outside of their
+    // enter animation
+    this.g.selectAll('.blast').remove();
+    this.update();
   }
 
   update() {
@@ -325,7 +339,7 @@ class WorldMap extends PureComponent {
     const clientRadius = 3;
 
     // bind to viewable points
-    const points = this.g.selectAll('.client')
+    const points = this.g.select('.clients').selectAll('.client')
       .data(viewable, (d) => d.id);
 
     // // points enter
@@ -366,7 +380,7 @@ class WorldMap extends PureComponent {
     const blastTransitionSpeed = 2000;
     const blastData = viewable[viewable.length - 1];
 
-    const blast = this.g.selectAll('.blast')
+    const blast = this.g.select('.blasts').selectAll('.blast')
       .data([blastData], (d) => d.id);
 
     this.path.pointRadius(0);
@@ -392,7 +406,7 @@ class WorldMap extends PureComponent {
     const { servers } = this.props;
     // SERVERS
     this.path.pointRadius(3);
-    const server = this.g.selectAll('.server')
+    const server = this.g.select('.servers').selectAll('.server')
       .data(servers, (d) => d.id);
 
     const serverE = server.enter()
@@ -419,7 +433,7 @@ class WorldMap extends PureComponent {
     const lineData = viewable.slice(minLineIndex, viewable.length);
 
     // bind to the line data
-    const lines = this.g.selectAll('.line')
+    const lines = this.g.select('.client-server-lines').selectAll('.line')
       .data(lineData, (d) => d.id);
 
     const linesE = lines.enter()
@@ -446,22 +460,12 @@ class WorldMap extends PureComponent {
   }
 
   /**
-   * Callback for when the map is zoomed
-   */
-  resetView() {
-    // remove blasts when resetting view since they do not exist outside of their
-    // enter animation
-    this.g.selectAll('.blast').remove();
-    this.update();
-  }
-
-
-  /**
    * Render
    */
   render() {
     const styles = { height: '600px' };
 
+    /* eslint-disable max-len */
     return (
       <div className="WorldMapContainer">
         <div

--- a/src/components/WorldMap/WorldMap.scss
+++ b/src/components/WorldMap/WorldMap.scss
@@ -17,6 +17,6 @@
     fill: none;
     stroke: #444;
     stroke-opacity: 0.4;
-    stroke-width: 2px;
+    stroke-width: 1.5px;
   }
 }

--- a/static/refill-style.yaml
+++ b/static/refill-style.yaml
@@ -719,8 +719,8 @@ styles:
         mix: [space-constant, patterns-stripes]
         shaders:
             defines:
-                COLOR1: vec3(0.915)
-                COLOR2: vec3(0.950)
+                COLOR1: vec3(0.95) # thin line
+                COLOR2: vec3(0.98) # thick line
             blocks:
                 global: |
                     float stripes2(vec2 st){
@@ -733,9 +733,10 @@ styles:
                     const float wave_height = .01;
                     st.y += sin(st.x*wave_width)*wave_height;
 
+                    color = mix(vec4(COLOR1, 1.0),vec4(COLOR2,1.0),stripes(st*92.,.5))*1.0;
                     // gradient
-                    color.rgb = mix(COLOR1, color.rgb, gl_FragCoord.x / u_resolution.x);
-                    color = mix(color,vec4(COLOR2,1.0),stripes(st*92.,.5))*1.0;
+                    // color.rgb = mix(COLOR1, color.rgb, gl_FragCoord.x / u_resolution.x);
+                    // color = mix(color,vec4(COLOR2,1.0),stripes(st*92.,.5))*1.0;
 
     waves2:
         base: polygons

--- a/static/refill-style.yaml
+++ b/static/refill-style.yaml
@@ -773,7 +773,7 @@ styles:
                     }
                 color: |
                     vec2 st = getConstantCoords();
-                    color = mix(vec4(color.rgb, 0.9), vec4(0.0), stripes(st*130.))*.8; // transparent stripes
+                    color = vec4(0.850, 0.850, 0.850, 0.9); //mix(vec4(color.rgb, 0.9), vec4(0.0), stripes(st*130.))*.8; // transparent stripes
 
     dots:
         mix: [space-tile, tiling-tile, shapes-circle]

--- a/static/refill-style.yaml
+++ b/static/refill-style.yaml
@@ -774,7 +774,7 @@ styles:
                     }
                 color: |
                     vec2 st = getConstantCoords();
-                    color = vec4(0.850, 0.850, 0.850, 0.9); //mix(vec4(color.rgb, 0.9), vec4(0.0), stripes(st*130.))*.8; // transparent stripes
+                    color = vec4(0.83, 0.83, 0.83, 0.9); //mix(vec4(color.rgb, 0.9), vec4(0.0), stripes(st*130.))*.8; // transparent stripes
 
     dots:
         mix: [space-tile, tiling-tile, shapes-circle]


### PR DESCRIPTION
- Makes coastlines solid instead of dashed (#180)
- Lightens water colors
- Fixes timer not stopping bug (#218)
- Makes lines disappear into server (#132)
- Fix bug where servers were added multiple times (1000 servers down to 49)
- Fix bug where lines did not reproject on zoom (#213)
- Improves server visibility by putting them in a group (#148)

![image](https://cloud.githubusercontent.com/assets/793847/19612975/b21724e4-97b7-11e6-97e8-8a1732cc9b6e.png)
