### PR TITLE
Use terrain map from stamen if no webgl support.

### DIFF
--- a/src/components/WorldMap/WorldMap.jsx
+++ b/src/components/WorldMap/WorldMap.jsx
@@ -6,6 +6,8 @@ import { pointToFeature, pointsToLine } from '../../utils/geo';
 
 import { createJaggedPoints } from '../../utils/path';
 
+import { hasWebgl } from '../../utils/webgl';
+
 import './leaflet.css';
 import './WorldMap.scss';
 
@@ -227,10 +229,19 @@ class WorldMap extends PureComponent {
       this.map = L.map(this.root,
         { maxZoom: 4, minZoom: 2, scrollWheelZoom: false }
       );
-      const layer = Tangram.leafletLayer({
-        scene: 'refill-style.yaml',
-        attribution: '<a href="https://mapzen.com/tangram" target="_blank">Tangram</a> | &copy; OSM contributors | <a href="https://mapzen.com/" target="_blank">Mapzen</a>',
-      });
+
+      let layer = null;
+
+      if (hasWebgl()) {
+        // use our sweet sweet tangram map
+        layer = Tangram.leafletLayer({
+          scene: 'refill-style.yaml',
+          attribution: '<a href="https://mapzen.com/tangram" target="_blank">Tangram</a> | &copy; OSM contributors | <a href="https://mapzen.com/" target="_blank">Mapzen</a>',
+        });
+      } else {
+        // use boring old terrain
+        layer = new L.StamenTileLayer('terrain');
+      }
 
       this.map.setView(location, zoom);
       layer.addTo(this.map);

--- a/src/server/Html.jsx
+++ b/src/server/Html.jsx
@@ -23,6 +23,8 @@ export default class Html extends Component {
     const { assets } = this.props;
     if (__DEVELOPMENT__) {
       // in dev we separate vendor out for faster webpack rebuild times.
+      // We do not have the ability to check for WebGL capabilities on server side,
+      // so need both stamen and tangram included.
       return [
         <script key="vendor" src={assets.javascript.vendor} charSet="UTF-8" />,
         <script key="leaflet" src="//cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-beta.2/leaflet.js" charSet="UTF-8" />,

--- a/src/server/Html.jsx
+++ b/src/server/Html.jsx
@@ -27,6 +27,7 @@ export default class Html extends Component {
         <script key="vendor" src={assets.javascript.vendor} charSet="UTF-8" />,
         <script key="leaflet" src="//cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-beta.2/leaflet.js" charSet="UTF-8" />,
         <script key="tangram" src="//mapzen.com/tangram/0.8/tangram.min.js" charSet="UTF-8" />,
+        <script key="stamen" src="//maps.stamen.com/js/tile.stamen.js?v1.3.0" charSet="UTF-8" />,
         <script key="main" src="//localhost:3001/dist/main.js" charSet="UTF-8" />,
       ];
     }
@@ -34,6 +35,7 @@ export default class Html extends Component {
     return [
       <script key="leaflet" src="//cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-beta.2/leaflet.js" charSet="UTF-8" />,
       <script key="tangram" src="//mapzen.com/tangram/0.8/tangram.min.js" charSet="UTF-8" />,
+      <script key="stamen" src="//maps.stamen.com/js/tile.stamen.js?v1.3.0" charSet="UTF-8" />,
       <script key="main" src={assets.javascript.main} charSet="UTF-8" />,
     ];
   }

--- a/src/utils/webgl.js
+++ b/src/utils/webgl.js
@@ -1,0 +1,28 @@
+
+
+// from: http://www.browserleaks.com/webgl#howto-detect-webgl
+export function hasWebgl()
+{
+  if (!!window.WebGLRenderingContext) {
+    const canvas = document.createElement('canvas');
+    const names = ['webgl', 'experimental-webgl', 'moz-webgl'];
+    let gl = false;
+
+    for (let i in names) {
+      try {
+        gl = canvas.getContext(names[i]);
+        if (gl && typeof gl.getParameter == 'function') {
+          /* WebGL is enabled */
+          /* return true; */
+          return names[i];
+        }
+      } catch (e) {}
+    }
+
+    /* WebGL is supported, but disabled */
+    return false;
+  }
+
+  /* WebGL not supported*/
+  return false;
+}


### PR DESCRIPTION
Terrain certainly isn't as cool as our tangram map - but it will suffice -and requires no additional upkeep / accounts - unlike if we were to use a mapbox or googlemap layer...


<img width="1169" alt="screen shot 2016-11-01 at 8 44 07 am" src="https://cloud.githubusercontent.com/assets/9369/19895974/0361ee00-a010-11e6-889b-192e499e4af5.png">

Tested webgl checking code on firefox by disabling webgl.

<img width="779" alt="screen shot 2016-11-01 at 8 48 56 am" src="https://cloud.githubusercontent.com/assets/9369/19895998/147810d4-a010-11e6-868e-88daefbdaf6d.png">


